### PR TITLE
FOLSPRINGB-83: Upgrade postgresql to 42.5.1 fixing CVE-2022-41946

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
            and spring-boot-starter-parent doesn't bump the postgresql minor version
            https://github.com/spring-projects/spring-boot/issues/32126
       -->
-      <version>42.5.0</version>
+      <version>42.5.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrade postgresql from 42.5.0 to 42.5.1 fixing Information Exposure:

https://nvd.nist.gov/vuln/detail/CVE-2022-41946