### PR TITLE
FOLSPRINGB-105: Spring Boot 3.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.5</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>


### PR DESCRIPTION
https://issues.folio.org/browse/FOLSPRINGB-105

Upgrade spring-boot-starter-parent from 3.0.2 to 3.0.5.