### PR TITLE
FOLSPRINGB-106 implementation for store/restore of FolioExecutionContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,41 @@ void ayncMethod(Map<String, Collection<String>> headers) {
   }
 }
 ```
+FOLIO scope implementation supports nested FolioExecutionContexts it means that the following code works correctly for
+```
+// Autowired
+private final FolioModuleMetadata folioModuleMetadata;
+
+// Autowired
+protected final FolioExecutionContext context;
+
+void someMethod(Map<String, Collection<String>> headers) {
+  Map<String, Collection<String>> headers1 = getHeaderForTenant("Tenant1");
+  try (var x = new FolioExecutionContextSetter(folioModuleMetadata, headers1)) {
+    String tenant1 = context.getTenantId();
+    businessMethod(tenant1);
+
+    Map<String, Collection<String>> headers2 = getHeaderForTenant("Tenant2");
+    try (var x = new FolioExecutionContextSetter(folioModuleMetadata, headers2)) {
+      String tenant2 = context.getTenantId();
+      businessMethod(tenant2);
+    }
+    
+    String tenant1_1 = context.getTenantId();
+    assert tenant1.equals(tenant1_1);
+  }
+}
+
+...
+
+void businessMethod(String tenantId) {
+  _do_some_useful_stuff_
+  String tenantId = context.getTenantId();
+
+  assert tenant.equals(tenantId);
+}
+```
+
 
 ## Properties
 

--- a/folio-spring-base/src/main/java/org/folio/spring/logging/FolioLoggingContextHolder.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/logging/FolioLoggingContextHolder.java
@@ -15,8 +15,12 @@ public final class FolioLoggingContextHolder {
     LogManager.getContext().putObject(FOLIO_EXECUTION_CONTEXT_KEY, folioExecutionContext);
   }
 
-  public static void removeFolioExecutionContext() {
-    LogManager.getContext().removeObject(FOLIO_EXECUTION_CONTEXT_KEY);
+  public static void removeFolioExecutionContext(FolioExecutionContext folioExecutionContextToRestore) {
+    if (folioExecutionContextToRestore == null) {
+      LogManager.getContext().removeObject(FOLIO_EXECUTION_CONTEXT_KEY);
+    } else {
+      LogManager.getContext().putObject(FOLIO_EXECUTION_CONTEXT_KEY, folioExecutionContextToRestore);
+    }
   }
 
   public static Optional<FolioExecutionContext> getFolioExecutionContext() {

--- a/folio-spring-base/src/test/java/org/folio/spring/logging/FolioLoggingContextLookupTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/logging/FolioLoggingContextLookupTest.java
@@ -22,7 +22,7 @@ class FolioLoggingContextLookupTest {
 
   @BeforeEach
   void setUp() {
-    FolioLoggingContextHolder.removeFolioExecutionContext();
+    FolioLoggingContextHolder.removeFolioExecutionContext(null);
   }
 
   @Test

--- a/folio-spring-base/src/test/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManagerTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManagerTest.java
@@ -47,13 +47,37 @@ class FolioExecutionScopeExecutionContextManagerTest {
 
   @Test
   void getRunnableWithCurrentFolioContext() {
-    Collection<String> headerValueCollection = List.of("dummy-tenanant-1");
+    Collection<String> headerValueCollection = List.of("dummy-tenant-2");
     var allHeaders = Map.of(TENANT, headerValueCollection);
     var localFolioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, allHeaders);
     Runnable task;
     FolioExecutionScopeExecutionContextManager.beginFolioExecutionContext(localFolioExecutionContext);
     try {
       task = FolioExecutionScopeExecutionContextManager.getRunnableWithCurrentFolioContext(() -> {
+        var tenantId = folioExecutionContext.getTenantId();
+        var localTenantId = localFolioExecutionContext.getTenantId();
+        assertEquals(tenantId, localTenantId);
+        var instance = folioExecutionContext.getInstance();
+        assertEquals(localFolioExecutionContext, instance);
+      });
+    } finally {
+      FolioExecutionScopeExecutionContextManager.endFolioExecutionContext();
+    }
+    task.run();
+  }
+
+  @Test
+  void getRunnableWithCurrentFolioContextWithStack() {
+    Collection<String> headerValueCollection = List.of("dummy-tenant-3");
+    var allHeaders = Map.of(TENANT, headerValueCollection);
+    var localFolioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, allHeaders);
+    Runnable task;
+    FolioExecutionScopeExecutionContextManager.beginFolioExecutionContext(localFolioExecutionContext);
+    try {
+      task = FolioExecutionScopeExecutionContextManager.getRunnableWithCurrentFolioContext(() -> {
+        // push & pop for FolioContext
+        getRunnableWithFolioContext();
+
         var tenantId = folioExecutionContext.getTenantId();
         var localTenantId = localFolioExecutionContext.getTenantId();
         assertEquals(tenantId, localTenantId);


### PR DESCRIPTION
## Purpose
It is required to support the temporary switching of FolioExecutionContext and restore the previous context when the temporary context is finished.

## Approach
Use a stack to store and restore the previous context
