### PR TITLE
FOLSPRINGB-111: Spring Boot 3.1.1 fixing CVE-2023-34981

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.0</version> <!-- also change spring-boot.version -->
+    <version>3.1.1</version> <!-- also change spring-boot.version -->
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -26,7 +26,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <spring-boot.version>3.1.0</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
+    <spring-boot.version>3.1.1</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
     <spring-cloud-starter-openfeign.version>4.0.3</spring-cloud-starter-openfeign.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>


### PR DESCRIPTION
Upgrade Spring Boot from 3.1.0 to 3.1.1 fixing Information Exposure:
https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHETOMCATEMBED-5726234