### PR TITLE
Create a new deque for every Thread

### DIFF
--- a/folio-spring-base/src/main/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManager.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManager.java
@@ -47,6 +47,17 @@ public class FolioExecutionScopeExecutionContextManager {
       protected Deque<FolioExecutionContext> initialValue() {
         return new ArrayDeque<>();
       }
+
+      @Override
+      protected Deque<FolioExecutionContext> childValue(Deque<FolioExecutionContext> parentValue) {
+        var result = initialValue();
+        if (parentValue != null && !parentValue.isEmpty()) {
+          result.push((FolioExecutionContext) parentValue.peek().getInstance());
+        }
+        log.debug(
+          "InheritableThreadLocal folioExecutionScopeHolder childValue: {}", Thread.currentThread().getName());
+        return result;
+      }
     };
 
   private static final InheritableThreadLocal<Deque<Map<String, Object>>> folioExecutionScopeHolder =
@@ -55,6 +66,19 @@ public class FolioExecutionScopeExecutionContextManager {
       protected Deque<Map<String, Object>> initialValue() {
         return new ArrayDeque<>();
       }
+
+      @Override
+      protected Deque<Map<String, Object>> childValue(Deque<Map<String, Object>> parentValue) {
+        var result = initialValue();
+        if (parentValue != null && !parentValue.isEmpty()) {
+          var scope = new ConcurrentHashMap<>(parentValue.peek());
+          result.push(scope);
+        }
+        log.debug(
+          "InheritableThreadLocal folioExecutionContextHolder childValue: {}", Thread.currentThread().getName());
+        return result;
+      }
+
     };
   private static final String EXECUTION_SCOPE_NOT_SET_UP_MSG =
     "FolioExecutionScope is not set up. Fallback to default FolioExecutionScope.";


### PR DESCRIPTION
## Purpose
The goal is to fix the implementation of deque management for FolioContext. The current implementation has a defect in the propagation of the InheritableThreadLocal to the child thread. As a result both parent and child threads shared the same deque.

## Approach
Override the childValue method in the NamedInheritableThreadLocal
