### PR TITLE
FOLSPRINGB-117: Extend Cql to JPA Criteria with support to JPA Specification

### DIFF
--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/domain/Person.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/domain/Person.java
@@ -26,6 +26,7 @@ public class Person {
   private Boolean isAlive;
   private Date dateBorn;
   private LocalDateTime localDate;
+  private boolean deleted = false;
 
   @ManyToOne
   @JoinColumn(name = "city_id")

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/PersonCustomRepository.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/PersonCustomRepository.java
@@ -1,0 +1,16 @@
+package org.folio.spring.cql.repo;
+
+import org.folio.spring.cql.domain.Person;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+public interface PersonCustomRepository {
+  static Specification<Person> deletedIs(Boolean deleted) {
+    return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("deleted"), deleted);
+  }
+
+  Page<Person> findByCqlAndDeletedFalse(String cql, Pageable pageable);
+
+  long countDeletedFalse(String cql);
+}

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/PersonCustomRepositoryImpl.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/PersonCustomRepositoryImpl.java
@@ -1,0 +1,54 @@
+package org.folio.spring.cql.repo;
+
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import org.folio.spring.cql.Cql2JpaCriteria;
+import org.folio.spring.cql.domain.Person;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.support.PageableExecutionUtils;
+
+public class PersonCustomRepositoryImpl implements PersonCustomRepository {
+
+  private final EntityManager em;
+  private final Cql2JpaCriteria<Person> cql2JpaCriteria;
+
+  public PersonCustomRepositoryImpl(EntityManager em) {
+    this.em = em;
+    this.cql2JpaCriteria = new Cql2JpaCriteria<>(Person.class, em);
+  }
+
+  @Override
+  public Page<Person> findByCqlAndDeletedFalse(String cql, Pageable pageable) {
+    var collectBy = collectByQueryAndDeletedFalse(cql);
+    var countBy = countByQueryAndDeletedFalse(cql);
+    var criteria = cql2JpaCriteria.toCollectCriteria(collectBy);
+
+    List<Person> resultList = em
+      .createQuery(criteria)
+      .setFirstResult((int) pageable.getOffset())
+      .setMaxResults(pageable.getPageSize())
+      .getResultList();
+    return PageableExecutionUtils.getPage(resultList, pageable, () -> count(countBy));
+  }
+
+  @Override
+  public long countDeletedFalse(String cql) {
+    var countBy = countByQueryAndDeletedFalse(cql);
+    return count(countBy);
+  }
+
+  private long count(Specification<Person> specification) {
+    var criteria = cql2JpaCriteria.toCountCriteria(specification);
+    return em.createQuery(criteria).getSingleResult();
+  }
+
+  private Specification<Person> collectByQueryAndDeletedFalse(String cqlQuery) {
+    return PersonCustomRepository.deletedIs(false).and(cql2JpaCriteria.createCollectSpecification(cqlQuery));
+  }
+
+  private Specification<Person> countByQueryAndDeletedFalse(String cqlQuery) {
+    return PersonCustomRepository.deletedIs(false).and(cql2JpaCriteria.createCountSpecification(cqlQuery));
+  }
+}

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/PersonRepository.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/PersonRepository.java
@@ -3,4 +3,4 @@ package org.folio.spring.cql.repo;
 import org.folio.spring.cql.JpaCqlRepository;
 import org.folio.spring.cql.domain.Person;
 
-public interface PersonRepository extends JpaCqlRepository<Person, Integer> {}
+public interface PersonRepository extends JpaCqlRepository<Person, Integer>, PersonCustomRepository {}

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-general-it-schema.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-general-it-schema.sql
@@ -4,5 +4,5 @@ DROP TABLE IF EXISTS
   str;
 
 CREATE TABLE city(id INT PRIMARY KEY, name VARCHAR(255));
-CREATE TABLE person(id INT PRIMARY KEY, name VARCHAR(255), age INT, identifier UUID, is_alive boolean, date_born timestamp, local_date timestamp, city_id INT REFERENCES city(id));
+CREATE TABLE person(id INT PRIMARY KEY, name VARCHAR(255), age INT, identifier UUID, is_alive boolean, date_born timestamp, local_date timestamp, city_id INT REFERENCES city(id), deleted boolean);
 CREATE TABLE str(id INT PRIMARY KEY, str text);

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-general-test-data.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-general-test-data.sql
@@ -1,9 +1,9 @@
 insert into city(id, name) values (1, 'Kharkiv');
 insert into city(id, name) values (2, 'Kyiv');
 
-insert into person(id, name, age, city_id, date_born, local_date) values (101, 'Jane', 20, 1, '2001-01-03', '2001-01-03');
-insert into person(id, name, age, city_id, date_born, local_date) values (102, 'John', 22, 2, '2001-01-01', '2001-01-01');
-insert into person(id, name, age, city_id, date_born, local_date) values (103, 'John', 40, 1, '2001-01-02', '2001-01-02');
+insert into person(id, name, age, city_id, date_born, local_date, deleted) values (101, 'Jane', 20, 1, '2001-01-03', '2001-01-03', false);
+insert into person(id, name, age, city_id, date_born, local_date, deleted) values (102, 'John', 22, 2, '2001-01-01', '2001-01-01', false);
+insert into person(id, name, age, city_id, date_born, local_date, deleted) values (103, 'John', 40, 1, '2001-01-02', '2001-01-02', false);
 
 insert into str(id, str) values
   (1, 'a'),

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-person-test-data.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-person-test-data.sql
@@ -1,0 +1,4 @@
+insert into person(id, name, age, city_id, date_born, local_date, deleted) values (104, 'Jane', 26, 1, '2001-01-03', '2001-01-03', false);
+insert into person(id, name, age, city_id, date_born, local_date, deleted) values (105, 'John', 30, 1, '2001-01-02', '2001-01-02', false);
+insert into person(id, name, age, city_id, date_born, local_date, deleted) values (106, 'Jane', 32, 1, '2001-01-03', '2001-01-03', true);
+insert into person(id, name, age, city_id, date_born, local_date, deleted) values (107, 'John', 33, 1, '2001-01-02', '2001-01-02', true);


### PR DESCRIPTION
## Purpose
_In order to have more complex cql criteria queries we need to have possibility to extend the conditions for these queries in a flexible manner._

## Approach
_Add JPA Specification support_

## Learning
[_FOLSPRINGB-117_](https://issues.folio.org/browse/FOLSPRINGB-117)

Specific use case of one such query can be found in the following [PR](https://github.com/folio-org/mod-entities-links/pull/136/files#diff-562ae46213cadf3444fb756a3882131a1ec13bf10c8d04bfaaf6e1f383caceed)
