### PR TITLE
FOLSPRINGB-118: Implement refresh token rotation method for edge module

### DIFF
--- a/folio-spring-system-user/pom.xml
+++ b/folio-spring-system-user/pom.xml
@@ -62,7 +62,11 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context-support</artifactId>
+      <version>6.0.7</version>
+    </dependency>
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-api-utils</artifactId>

--- a/folio-spring-system-user/pom.xml
+++ b/folio-spring-system-user/pom.xml
@@ -41,6 +41,21 @@
       <artifactId>lombok</artifactId>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
+      <scope>provided</scope>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -61,11 +76,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-http</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context-support</artifactId>
-      <version>6.0.7</version>
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>

--- a/folio-spring-system-user/src/main/java/org/folio/spring/config/SystemUserConfig.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/config/SystemUserConfig.java
@@ -1,4 +1,4 @@
-package org.folio.spring.config.properties;
+package org.folio.spring.config;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;

--- a/folio-spring-system-user/src/main/java/org/folio/spring/config/properties/SystemUserConfig.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/config/properties/SystemUserConfig.java
@@ -1,0 +1,33 @@
+package org.folio.spring.config.properties;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.folio.spring.model.SystemUser;
+import org.folio.spring.service.SystemUserProperties;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ComponentScan(basePackages = {
+  "org.folio.spring.client",
+  "org.folio.spring.context",
+  "org.folio.spring.service",
+  "org.folio.spring.config.properties",
+})
+@EnableFeignClients(basePackages = "org.folio.spring.client")
+@ConditionalOnProperty(prefix = "folio.system-user", name = "username")
+@EnableConfigurationProperties({SystemUserProperties.class})
+public class SystemUserConfig {
+
+  @Bean
+  @ConditionalOnClass({Caffeine.class, CaffeineCacheManager.class})
+  public Cache<String, SystemUser> systemUserCache() {
+    return Caffeine.from("maximumSize=500,expireAfterWrite=3600s").build();
+  }
+}

--- a/folio-spring-system-user/src/main/java/org/folio/spring/model/ResultList.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/model/ResultList.java
@@ -2,6 +2,7 @@ package org.folio.spring.model;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor(staticName = "of")
+@JsonIgnoreProperties("resultInfo")
 public class ResultList<T> {
 
   /**

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
@@ -31,6 +31,7 @@ import org.springframework.util.CollectionUtils;
 public class SystemUserService {
 
   public static final String CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT = "Cannot retrieve okapi token for tenant: ";
+  public static final String LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR = "Login with legacy end-point returned unexpected error";
   private final ExecutionContextBuilder contextBuilder;
   private final SystemUserProperties systemUserProperties;
   private final FolioEnvironment environment;
@@ -138,13 +139,14 @@ public class SystemUserService {
         log.info("Login with legacy end-point not found");
         throw new AuthorizationException(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT + user.username());
       } else {
-        log.info("Login with legacy end-point returned unexpected error");
+        log.info(LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR);
         throw new AuthorizationException(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT + user.username());
       }
     }
   }
 
   private UserToken getTokenLegacy(String tenantId, String username, String password) {
+    log.info("Attempting to issue token for system user [tenantId={}]", tenantId);
     try {
       var response =
           authnClient.login(new UserCredentials(username, password));
@@ -161,7 +163,7 @@ public class SystemUserService {
         log.info("Login with legacy end-point not found");
         throw new AuthorizationException(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT + username);
       } else {
-        log.info("Login with legacy end-point returned unexpected error");
+        log.info(LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR);
         throw new AuthorizationException(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT + username);
       }
     }
@@ -192,7 +194,7 @@ public class SystemUserService {
         log.info("Login with legacy end-point not found. calling login with legacy end-point.");
         return getTokenLegacy(user);
       } else {
-        log.info("Login with legacy end-point returned unexpected error");
+        log.info(LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR);
         throw new AuthorizationException(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT + user.username());
       }
     }
@@ -223,7 +225,7 @@ public class SystemUserService {
         log.info("Login with legacy end-point not found. calling login with legacy end-point.");
         return getTokenLegacy(tenantId, username, password);
       } else {
-        log.info("Login with legacy end-point returned unexpected error");
+        log.info(LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR);
         throw new AuthorizationException(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT + username);
       }
     }

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
@@ -33,6 +33,8 @@ public class SystemUserService {
   public static final String CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT = "Cannot retrieve okapi token for tenant: ";
   public static final String
       LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR = "Login with legacy end-point returned unexpected error";
+  public static final String
+      LOGIN_WITH_EXPIRY_END_POINT_RETURNED_UNEXPECTED_ERROR = "Login with expiry end-point returned unexpected error";
   public static final String LOGIN_WITH_EXPIRY = "login with expiry";
   private final ExecutionContextBuilder contextBuilder;
   private final SystemUserProperties systemUserProperties;
@@ -176,7 +178,7 @@ public class SystemUserService {
         log.error("Login with legacy end-point not found. calling login with legacy end-point.");
         return null;
       } else {
-        log.error(LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR);
+        log.error(LOGIN_WITH_EXPIRY_END_POINT_RETURNED_UNEXPECTED_ERROR);
         throw new AuthorizationException(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT + credentials.username());
       }
     }

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
@@ -176,7 +176,7 @@ public class SystemUserService {
     } catch (FeignException fex) {
       if (fex.status() == HttpStatus.NOT_FOUND.value()) {
         log.error("Login with legacy end-point not found. calling login with legacy end-point.");
-        return getTokenLegacy(credentials);
+        return null;
       } else {
         log.error(LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR);
         throw new AuthorizationException(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT + credentials.username());

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
@@ -31,7 +31,9 @@ import org.springframework.util.CollectionUtils;
 public class SystemUserService {
 
   public static final String CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT = "Cannot retrieve okapi token for tenant: ";
-  public static final String LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR = "Login with legacy end-point returned unexpected error";
+  public static final String
+      LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR = "Login with legacy end-point returned unexpected error";
+  public static final String LOGIN_WITH_EXPIRY = "login with expiry";
   private final ExecutionContextBuilder contextBuilder;
   private final SystemUserProperties systemUserProperties;
   private final FolioEnvironment environment;
@@ -177,7 +179,7 @@ public class SystemUserService {
       if (isNull(response.getBody())) {
         throw new IllegalStateException(
             String.format("User [%s] cannot %s because expire times missing for status %s",
-            user.username(), "login with expiry", response.getStatusCode()));
+            user.username(), LOGIN_WITH_EXPIRY, response.getStatusCode()));
       }
 
       var cookieHeaders = response.getHeaders().get(SET_COOKIE);
@@ -185,7 +187,7 @@ public class SystemUserService {
       if (isNull(cookieHeaders) || CollectionUtils.isEmpty(cookieHeaders)) {
         throw new IllegalStateException(
             String.format("User [%s] cannot %s because of missing tokens",
-                user.username(), "login with expiry"));
+                user.username(), LOGIN_WITH_EXPIRY));
       }
 
       return parseUserTokenFromCookies(cookieHeaders, response.getBody());
@@ -208,7 +210,7 @@ public class SystemUserService {
       if (isNull(response.getBody())) {
         throw new IllegalStateException(
             String.format("User [%s] cannot %s because expire times missing for status %s",
-                username, "login with expiry", response.getStatusCode()));
+                username, LOGIN_WITH_EXPIRY, response.getStatusCode()));
       }
 
       var cookieHeaders = response.getHeaders().get(SET_COOKIE);
@@ -216,7 +218,7 @@ public class SystemUserService {
       if (isNull(cookieHeaders) || CollectionUtils.isEmpty(cookieHeaders)) {
         throw new IllegalStateException(
             String.format("User [%s] cannot %s because of missing tokens",
-                username, "login with expiry"));
+                username, LOGIN_WITH_EXPIRY));
       }
 
       return parseUserTokenFromCookies(cookieHeaders, response.getBody());

--- a/folio-spring-system-user/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/folio-spring-system-user/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,1 @@
-org.folio.spring.tools.config.SystemUserConfig
+org.folio.spring.config.SystemUserConfig

--- a/folio-spring-system-user/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/folio-spring-system-user/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.folio.spring.tools.config.SystemUserConfig

--- a/folio-spring-system-user/src/test/java/org/folio/spring/systemuser/SystemUserServiceTest.java
+++ b/folio-spring-system-user/src/test/java/org/folio/spring/systemuser/SystemUserServiceTest.java
@@ -244,7 +244,7 @@ class SystemUserServiceTest {
   }
 
   @Test
-  void authSystemUser_when_loginExipry_notFoundException() {
+  void authSystemUser_when_loginExpiry_notFoundException() {
     var expectedUserToken = new UserToken(MOCK_TOKEN, Instant.MAX);
     doThrow(FeignException.errorStatus("GET", create404Response()))
         .when(authnClient).loginWithExpiry(any());
@@ -257,7 +257,7 @@ class SystemUserServiceTest {
   }
 
   @Test
-  void overloaded_authSystemUser_when_loginExipry_notFoundException() {
+  void overloaded_authSystemUser_when_loginExpiry_notFoundException() {
     var expectedUserToken = new UserToken(MOCK_TOKEN, Instant.MAX);
     doThrow(FeignException.errorStatus("GET", create404Response()))
         .when(authnClient).loginWithExpiry(any());
@@ -271,7 +271,7 @@ class SystemUserServiceTest {
   }
 
   @Test
-  void authSystemUser_when_loginExipry_notFoundException_loginLegacReturnsNull() {
+  void authSystemUser_when_loginExpiry_notFoundException_loginLegacReturnsNull() {
     var expectedUserToken = new UserToken(MOCK_TOKEN, Instant.MAX);
     doThrow(FeignException.errorStatus("GET", create404Response()))
         .when(authnClient).loginWithExpiry(any());
@@ -306,10 +306,20 @@ class SystemUserServiceTest {
   }
 
   @Test
-  void overloaded_authSystemUser_when_loginExipry_notFoundException_loginLegacReturnsNull() {
+  void overloaded_authSystemUser_when_loginExpiry_notFoundException_loginLegacReturnsNull() {
     var expectedUserToken = new UserToken(MOCK_TOKEN, Instant.MAX);
     when(contextBuilder.forSystemUser(any())).thenReturn(context);
     var systemUser = systemUserValue();
+    var systemUserService = systemUserService(systemUserProperties());
+    assertThatThrownBy(() -> systemUserService
+        .authSystemUser("tenantId", "username", "password"))
+        .isInstanceOf(AuthorizationException.class)
+        .hasMessage("Cannot retrieve okapi token for tenant: tenantId");
+  }
+
+  @Test
+  void overloaded_authSystemUser_when_loginExpiryReturnsNull() {
+    when(contextBuilder.forSystemUser(any())).thenReturn(context);
     var systemUserService = systemUserService(systemUserProperties());
     assertThatThrownBy(() -> systemUserService
         .authSystemUser("tenantId", "username", "password"))

--- a/folio-spring-system-user/src/test/java/org/folio/spring/systemuser/SystemUserServiceTest.java
+++ b/folio-spring-system-user/src/test/java/org/folio/spring/systemuser/SystemUserServiceTest.java
@@ -54,6 +54,8 @@ class SystemUserServiceTest {
   private static final String TENANT_ID = "test";
   private static final Instant TOKEN_EXPIRATION = Instant.now().plus(1, ChronoUnit.DAYS);
   private static final String MOCK_TOKEN = "test_token";
+  private static final String CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT_TENANT_ID
+      = "Cannot retrieve okapi token for tenant: tenantId";
   @Mock
   private AuthnClient authnClient;
   @Mock
@@ -182,9 +184,9 @@ class SystemUserServiceTest {
 
     var systemUserService = systemUserService(systemUserProperties());
     assertThatThrownBy(() -> systemUserService
-        .authSystemUser("tenanId", "username", "password"))
+        .authSystemUser("tenantId", "username", "password"))
         .isInstanceOf(AuthorizationException.class)
-        .hasMessage("Cannot retrieve okapi token for tenant: tenanId");
+        .hasMessage(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT_TENANT_ID);
   }
 
   @Test
@@ -214,7 +216,7 @@ class SystemUserServiceTest {
     assertThatThrownBy(() -> systemUserService
         .authSystemUser("tenantId", "username", "password"))
         .isInstanceOf(AuthorizationException.class)
-        .hasMessage("Cannot retrieve okapi token for tenant: tenantId");
+        .hasMessage(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT_TENANT_ID);
   }
 
   @Test
@@ -240,7 +242,7 @@ class SystemUserServiceTest {
     assertThatThrownBy(() -> systemUserService
         .authSystemUser("tenantId", "username", "password"))
         .isInstanceOf(AuthorizationException.class)
-        .hasMessage("Cannot retrieve okapi token for tenant: tenantId");
+        .hasMessage(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT_TENANT_ID);
   }
 
   @Test
@@ -302,7 +304,7 @@ class SystemUserServiceTest {
     assertThatThrownBy(() -> systemUserService
         .authSystemUser("tenantId", "username", "password"))
         .isInstanceOf(AuthorizationException.class)
-        .hasMessage("Cannot retrieve okapi token for tenant: tenantId");
+        .hasMessage(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT_TENANT_ID);
   }
 
   @Test
@@ -314,7 +316,7 @@ class SystemUserServiceTest {
     assertThatThrownBy(() -> systemUserService
         .authSystemUser("tenantId", "username", "password"))
         .isInstanceOf(AuthorizationException.class)
-        .hasMessage("Cannot retrieve okapi token for tenant: tenantId");
+        .hasMessage(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT_TENANT_ID);
   }
 
   @Test
@@ -324,7 +326,7 @@ class SystemUserServiceTest {
     assertThatThrownBy(() -> systemUserService
         .authSystemUser("tenantId", "username", "password"))
         .isInstanceOf(AuthorizationException.class)
-        .hasMessage("Cannot retrieve okapi token for tenant: tenantId");
+        .hasMessage(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT_TENANT_ID);
   }
 
   @Test
@@ -346,7 +348,7 @@ class SystemUserServiceTest {
     assertThatThrownBy(() -> systemUserService
         .authSystemUser("tenantId", "username", "password"))
         .isInstanceOf(AuthorizationException.class)
-        .hasMessage("Cannot retrieve okapi token for tenant: tenantId");
+        .hasMessage(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT_TENANT_ID);
   }
 
   private SystemUserService systemUserService(SystemUserProperties properties) {


### PR DESCRIPTION
## Purpose
_[FOLSPRINGB-118](https://issues.folio.org/browse/FOLSPRINGB-118) : Implement refresh token rotation method for edge module_

## Approach
method overloading of authSystemUser(), getTokenWithExpiry(), getTokenLegacy() by supplying tenantId, username, and password as arguments, which can be utilized into the edge-module which has a mechanism of retrieving password from the salt, unlike other mod-* modules which retrieves it from the module's properties file.

