### PR TITLE
FOLSPRINGB-119 : Token retrieved from cache can expire during the time it is used in a request

### DIFF
--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
@@ -32,10 +32,10 @@ public class SystemUserService {
   public static final String CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT = "Cannot retrieve okapi token for tenant: ";
   public static final String
       LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR = "Login with legacy end-point returned "
-      + "unexpected error: {}";
+      + "unexpected error";
   public static final String
       LOGIN_WITH_EXPIRY_END_POINT_RETURNED_UNEXPECTED_ERROR = "Login with expiry end-point returned "
-      + "unexpected error: {}";
+      + "unexpected error";
   public static final String LOGIN_WITH_EXPIRY = "login with expiry";
   public static final String
       LOGIN_WITH_EXPIRY_END_POINT_NOT_FOUND_CALLING_LOGIN_WITH_LEGACY_END_POINT = "Login with expiry end-point "
@@ -64,8 +64,7 @@ public class SystemUserService {
 
     var user = systemUserCache.get(tenantId, this::getSystemUser);
     var userToken = user.token();
-    var now = Instant.now().minusSeconds(30L);
-    if (userToken.accessTokenExpiration().isAfter(now)) {
+    if (userToken.accessTokenExpiration().isAfter(Instant.now().minusSeconds(30L))) {
       return user;
     }
 

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
@@ -24,7 +24,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
-
 @Log4j2
 @Service
 @RequiredArgsConstructor
@@ -32,10 +31,16 @@ public class SystemUserService {
 
   public static final String CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT = "Cannot retrieve okapi token for tenant: ";
   public static final String
-      LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR = "Login with legacy end-point returned unexpected error";
+      LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR = "Login with legacy end-point returned "
+      + "unexpected error: {}";
   public static final String
-      LOGIN_WITH_EXPIRY_END_POINT_RETURNED_UNEXPECTED_ERROR = "Login with expiry end-point returned unexpected error";
+      LOGIN_WITH_EXPIRY_END_POINT_RETURNED_UNEXPECTED_ERROR = "Login with expiry end-point returned "
+      + "unexpected error: {}";
   public static final String LOGIN_WITH_EXPIRY = "login with expiry";
+  public static final String
+      LOGIN_WITH_EXPIRY_END_POINT_NOT_FOUND_CALLING_LOGIN_WITH_LEGACY_END_POINT = "Login with expiry end-point "
+      + "not found. calling login with legacy end-point.";
+  public static final String LOGIN_WITH_LEGACY_END_POINT_NOT_FOUND = "Login with legacy end-point not found.";
   private final ExecutionContextBuilder contextBuilder;
   private final SystemUserProperties systemUserProperties;
   private final FolioEnvironment environment;
@@ -59,7 +64,7 @@ public class SystemUserService {
 
     var user = systemUserCache.get(tenantId, this::getSystemUser);
     var userToken = user.token();
-    var now = Instant.now();
+    var now = Instant.now().minusSeconds(30L);
     if (userToken.accessTokenExpiration().isAfter(now)) {
       return user;
     }
@@ -144,10 +149,10 @@ public class SystemUserService {
       return UserToken.builder().accessToken(accessToken).accessTokenExpiration(Instant.MAX).build();
     } catch (FeignException fex) {
       if (fex.status() == HttpStatus.NOT_FOUND.value()) {
-        log.error("Login with legacy end-point not found");
+        log.error(LOGIN_WITH_LEGACY_END_POINT_NOT_FOUND);
         throw new AuthorizationException(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT + credentials.username());
       } else {
-        log.error(LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR);
+        log.error(LOGIN_WITH_LEGACY_END_POINT_RETURNED_UNEXPECTED_ERROR, fex);
         throw new AuthorizationException(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT + credentials.username());
       }
     }
@@ -175,10 +180,10 @@ public class SystemUserService {
       return parseUserTokenFromCookies(cookieHeaders, response.getBody());
     } catch (FeignException fex) {
       if (fex.status() == HttpStatus.NOT_FOUND.value()) {
-        log.error("Login with legacy end-point not found. calling login with legacy end-point.");
+        log.error(LOGIN_WITH_EXPIRY_END_POINT_NOT_FOUND_CALLING_LOGIN_WITH_LEGACY_END_POINT);
         return null;
       } else {
-        log.error(LOGIN_WITH_EXPIRY_END_POINT_RETURNED_UNEXPECTED_ERROR);
+        log.error(LOGIN_WITH_EXPIRY_END_POINT_RETURNED_UNEXPECTED_ERROR, fex);
         throw new AuthorizationException(CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT + credentials.username());
       }
     }


### PR DESCRIPTION
[FOLSPRINGB-119](https://issues.folio.org/browse/FOLSPRINGB-119) : Token retrieved from cache can expire during the time it is used in a request

## Purpose
_In folio-spring-system-user when we retrieve the token from the cache, we first check to see if it is expired. However, the request will take some unknown amount of time. It would be rare but possible that the token could expire during the time after which it was retrieved and used in the actual request. Adding a buffer should be sufficient to solve this._

## Approach
_While comparing the cached token's expiration time with the current time, we compare it with the current time minus 30 seconds_
