### PR TITLE
FOLSPRINGB-120: Expired system user token from cache

### DIFF
--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
@@ -50,9 +50,9 @@ public class SystemUserService {
 
   /**
    * Get authenticate system user.
-   * Get from cache if present (or getSystemUser otherwise). Call login expiry endpoint in case
-   * access token expired. Call login endpoint in case login-expiry endpoint returns null or it
-   * doesn't exist
+   * 
+   * <p>Get from cache if present and is valid (not expired) for at least 30 seconds from now.
+   * Otherwise call login expiry endpoint to get a new system user token.
    *
    * @param tenantId The tenant name
    * @return {@link SystemUser} with token value
@@ -64,7 +64,7 @@ public class SystemUserService {
 
     var user = systemUserCache.get(tenantId, this::getSystemUser);
     var userToken = user.token();
-    if (userToken.accessTokenExpiration().isAfter(Instant.now().minusSeconds(30L))) {
+    if (userToken.accessTokenExpiration().isAfter(Instant.now().plusSeconds(30L))) {
       return user;
     }
 

--- a/folio-spring-system-user/src/test/java/org/folio/spring/systemuser/SystemUserServiceTest.java
+++ b/folio-spring-system-user/src/test/java/org/folio/spring/systemuser/SystemUserServiceTest.java
@@ -39,6 +39,8 @@ import org.folio.spring.service.SystemUserProperties;
 import org.folio.spring.service.SystemUserService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -99,9 +101,10 @@ class SystemUserServiceTest {
     assertThat(actual.userId()).isEqualTo(expectedUserId.toString());
   }
 
-  @Test
-  void getAuthedSystemUserUsingCache_positive() {
-    var expectedUserToken = userToken(Instant.now().plus(1, ChronoUnit.DAYS));
+  @ParameterizedTest
+  @ValueSource(ints = { 40, 24 * 60 * 60 })
+  void getAuthedSystemUserUsingCache_positive(int plusSeconds) {
+    var expectedUserToken = userToken(Instant.now().plusSeconds(plusSeconds));
     var systemUserService = systemUserService(systemUserProperties());
     systemUserService.setSystemUserCache(userCache);
 
@@ -115,9 +118,10 @@ class SystemUserServiceTest {
     verify(contextBuilder, never()).forSystemUser(any());
   }
 
-  @Test
-  void getAuthedSystemUserUsingCacheWithExpiredAccessToken_positive() {
-    var cachedUserToken = userToken(Instant.now().minus(1, ChronoUnit.DAYS));
+  @ParameterizedTest
+  @ValueSource(ints = { -24 * 60 * 60, -1, 30 })  // expires within 30 seconds
+  void getAuthedSystemUserUsingCacheWithExpiredAccessToken_positive(int plusSeconds) {
+    var cachedUserToken = userToken(Instant.now().plusSeconds(plusSeconds));
     var systemUserService = systemUserService(systemUserProperties());
     systemUserService.setSystemUserCache(userCache);
     when(contextBuilder.forSystemUser(any())).thenReturn(context);


### PR DESCRIPTION
The cached system user is returned when is has been expired for up to 30 seconds.

Cause:

SystemUserService.java uses Instant.now().minusSeconds(30L), it should use Instant.now().plusSeconds(30L).

Also add unit tests for this.

## Learning
Use unit tests.
Don't approve when the current feature has no unit test.
