### PR TITLE
FOLSPRINGB-121: okio-jvm 3.4.0 fixing DoS CVE-2023-3635

### DIFF
--- a/folio-spring-base/pom.xml
+++ b/folio-spring-base/pom.xml
@@ -90,6 +90,15 @@
       <version>${feign-okhttp.version}</version>
     </dependency>
 
+    <!-- fixes https://nvd.nist.gov/vuln/detail/CVE-2023-3635
+         remove when okhttp ships with okio-jvm >= 3.4.0 -->
+    <dependency>
+      <groupId>com.squareup.okio</groupId>
+      <artifactId>okio-jvm</artifactId>
+      <version>3.4.0</version>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- OAS generation -->
     <dependency>
       <groupId>org.openapitools</groupId>


### PR DESCRIPTION
Upgrade okio-jvm from 3.0.0 to 3.4.0 fixing a Denial of Service (DoS) vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2023-3635

A minor version bump is needed for this security fix. Upstream projects don't do a minor version bump, this must be done by FOLIO. It's compatible.
https://github.com/square/okhttp/issues/7944
https://github.com/square/okhttp/issues/7994
https://github.com/spring-projects/spring-boot/issues/36450
´