### PR TITLE
FOLSPRINGB-126: Reject empty and null system user password

### DIFF
--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserProperties.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserProperties.java
@@ -1,7 +1,13 @@
 package org.folio.spring.service;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("folio.system-user")
 public record SystemUserProperties(String username, String password, String lastname, String permissionsFilePath) {
+  public SystemUserProperties {
+    if (StringUtils.isEmpty(password)) {
+      throw new IllegalArgumentException("system user password must be configured to be non-empty");
+    }
+  }
 }

--- a/folio-spring-system-user/src/test/java/org/folio/spring/service/SystemUserPropertiesTest.java
+++ b/folio-spring-system-user/src/test/java/org/folio/spring/service/SystemUserPropertiesTest.java
@@ -1,0 +1,21 @@
+package org.folio.spring.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class SystemUserPropertiesTest {
+
+  @Test
+  void rejectEmptyPassword() {
+    assertThatThrownBy(() -> new SystemUserProperties("username", "", "lastname", "path"))
+        .as("system user password must be configured to be non-empty");
+  }
+
+  @Test
+  void rejectNullPassword() {
+    assertThatThrownBy(() -> new SystemUserProperties("username", null, "lastname", "path"))
+        .as("system user password must be configured to be non-empty");
+  }
+
+}

--- a/folio-spring-system-user/src/test/java/org/folio/spring/service/SystemUserPropertiesTest.java
+++ b/folio-spring-system-user/src/test/java/org/folio/spring/service/SystemUserPropertiesTest.java
@@ -1,6 +1,6 @@
 package org.folio.spring.service;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import org.junit.jupiter.api.Test;
 
@@ -8,14 +8,16 @@ class SystemUserPropertiesTest {
 
   @Test
   void rejectEmptyPassword() {
-    assertThatThrownBy(() -> new SystemUserProperties("username", "", "lastname", "path"))
-        .as("system user password must be configured to be non-empty");
+    assertThatIllegalArgumentException()
+      .isThrownBy(() -> new SystemUserProperties("username", "", "lastname", "path"))
+      .withMessage("system user password must be configured to be non-empty");
   }
 
   @Test
   void rejectNullPassword() {
-    assertThatThrownBy(() -> new SystemUserProperties("username", null, "lastname", "path"))
-        .as("system user password must be configured to be non-empty");
+    assertThatIllegalArgumentException()
+      .isThrownBy(() -> new SystemUserProperties("username", null, "lastname", "path"))
+      .withMessage("system user password must be configured to be non-empty");
   }
 
 }


### PR DESCRIPTION
The folio-spring-system-user library should reject an empty or null system user password.

Use case:

As a sysop I may accidentially forget to set the environment variable.

For example forgetting to add SYSTEM_USER_PASSWORD, or forget to add the secret to a deployment in Rancher, or having a typo in the variable name like SYSTEM_USERS_PASSWORD.

When the system user password is not set or is empty the attempt to create the system user when enabling the module for a tenant (or upgrading the module for a tenant) should fail with an error message about the missing password.

The module MUST NOT set an empty password.

This is security by default and is required for GDPR compliance (GDPR Article 25 "Data protection by design and by default").

Therefore folio-spring-system-user MUST reject a system user with null or empty password.

## Purpose
Reject empty and null system user password.

## Approach
Reject empty and null system user password.