### PR TITLE
FOLSPRINGB-128 System User POC

### DIFF
--- a/folio-spring-system-user/README.md
+++ b/folio-spring-system-user/README.md
@@ -41,4 +41,15 @@ Requirements:
 If system user was created during enabling for tenant, then the system user could be used to make request
 to other modules. To do so `SystemUserScopedExecutionService` could be used.
 
+### Disable system user functionality
+
+Setting property `folio.system-user.enabled=false` will disable system user functionality:
+* all actions called using `SystemUserScopedExecutionService` will be performed in `DefaultFolioExecutionContext`
+* `X-Okapi-Token` header won't be populated with system user JWT token value
+* All unused Spring components will be excluded from Spring context, including:
+  * `AuthnClient`
+  * `PermissionsClient`
+  * `UsersClient`
+  * `SystemUserService`
+
 ****

--- a/folio-spring-system-user/pom.xml
+++ b/folio-spring-system-user/pom.xml
@@ -10,6 +10,7 @@
 
   <name>folio-spring-system-user</name>
   <artifactId>folio-spring-system-user</artifactId>
+  <version>7.3.0-folspringb-128</version>
   <description />
 
   <properties>

--- a/folio-spring-system-user/src/main/java/org/folio/spring/config/OptionalSystemUserConfig.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/config/OptionalSystemUserConfig.java
@@ -1,0 +1,37 @@
+package org.folio.spring.config;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.folio.spring.client.AuthnClient;
+import org.folio.spring.config.properties.FolioEnvironment;
+import org.folio.spring.context.ExecutionContextBuilder;
+import org.folio.spring.model.SystemUser;
+import org.folio.spring.service.PrepareSystemUserService;
+import org.folio.spring.service.SystemUserProperties;
+import org.folio.spring.service.SystemUserService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackages = "org.folio.spring.client")
+@ConditionalOnProperty(name = "folio.system-user.enabled", havingValue = "true", matchIfMissing = true)
+public class OptionalSystemUserConfig {
+
+  @Bean
+  @ConditionalOnClass({Caffeine.class, CaffeineCacheManager.class})
+  public Cache<String, SystemUser> systemUserCache() {
+    return Caffeine.from("maximumSize=500,expireAfterWrite=3600s").build();
+  }
+
+  @Bean
+  public SystemUserService systemUserService(ExecutionContextBuilder executionContextBuilder,
+      SystemUserProperties systemUserProperties, FolioEnvironment folioEnvironment,
+      AuthnClient authnClient, PrepareSystemUserService prepareSystemUserService) {
+    return new SystemUserService(executionContextBuilder, systemUserProperties, folioEnvironment,
+      authnClient, prepareSystemUserService);
+  }
+}

--- a/folio-spring-system-user/src/main/java/org/folio/spring/config/SystemUserConfig.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/config/SystemUserConfig.java
@@ -1,15 +1,7 @@
 package org.folio.spring.config;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import org.folio.spring.model.SystemUser;
 import org.folio.spring.service.SystemUserProperties;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
-import org.springframework.cloud.openfeign.EnableFeignClients;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
@@ -20,14 +12,5 @@ import org.springframework.context.annotation.Configuration;
   "org.folio.spring.service",
   "org.folio.spring.config.properties",
 })
-@EnableFeignClients(basePackages = "org.folio.spring.client")
-@ConditionalOnProperty(prefix = "folio.system-user", name = "username")
 @EnableConfigurationProperties({SystemUserProperties.class})
-public class SystemUserConfig {
-
-  @Bean
-  @ConditionalOnClass({Caffeine.class, CaffeineCacheManager.class})
-  public Cache<String, SystemUser> systemUserCache() {
-    return Caffeine.from("maximumSize=500,expireAfterWrite=3600s").build();
-  }
-}
+public class SystemUserConfig {}

--- a/folio-spring-system-user/src/main/java/org/folio/spring/context/ExecutionContextBuilder.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/context/ExecutionContextBuilder.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.config.properties.FolioEnvironment;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.model.SystemUser;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ExecutionContextBuilder {
 
+  private final FolioEnvironment folioEnvironment;
   private final FolioModuleMetadata moduleMetadata;
 
   public FolioExecutionContext forSystemUser(SystemUser systemUser) {
@@ -27,6 +29,11 @@ public class ExecutionContextBuilder {
     var userId = systemUser.userId();
 
     return buildContext(okapiUrl, tenantId, token, userId, null);
+  }
+
+  public FolioExecutionContext buildContext(String tenantId) {
+    var okapiUrl = folioEnvironment.getOkapiUrl();
+    return buildContext(okapiUrl, tenantId, null, null, null);
   }
 
   private FolioExecutionContext buildContext(String okapiUrl, String tenantId, String token, String userId,

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/PrepareSystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/PrepareSystemUserService.java
@@ -18,6 +18,7 @@ import org.folio.spring.client.PermissionsClient.Permission;
 import org.folio.spring.client.PermissionsClient.Permissions;
 import org.folio.spring.client.UsersClient;
 import org.folio.spring.client.UsersClient.User;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 
@@ -28,12 +29,18 @@ public class PrepareSystemUserService {
 
   public static final String SYSTEM_USER_TYPE = "system";
 
-  private final UsersClient usersClient;
-  private final AuthnClient authnClient;
-  private final PermissionsClient permissionsClient;
   private final SystemUserProperties systemUserProperties;
 
+  private UsersClient usersClient;
+  private AuthnClient authnClient;
+  private PermissionsClient permissionsClient;
+
   public void setupSystemUser() {
+    if (!systemUserProperties.isEnabled()) {
+      log.info("System user is disabled, skipping setup operation");
+      return;
+    }
+
     log.info("Preparing system user...");
     var folioUser = getFolioUser(systemUserProperties.username());
     var userId = folioUser.map(User::id)
@@ -105,5 +112,20 @@ public class PrepareSystemUserService {
   private List<String> getResourceLines(String permissionsFilePath) {
     var resource = new ClassPathResource(permissionsFilePath);
     return IOUtils.readLines(resource.getInputStream(), StandardCharsets.UTF_8);
+  }
+
+  @Autowired(required = false)
+  public void setUsersClient(UsersClient usersClient) {
+    this.usersClient = usersClient;
+  }
+
+  @Autowired(required = false)
+  public void setAuthnClient(AuthnClient authnClient) {
+    this.authnClient = authnClient;
+  }
+
+  @Autowired(required = false)
+  public void setPermissionsClient(PermissionsClient permissionsClient) {
+    this.permissionsClient = permissionsClient;
   }
 }

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserProperties.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserProperties.java
@@ -1,7 +1,89 @@
 package org.folio.spring.service;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
 @ConfigurationProperties("folio.system-user")
-public record SystemUserProperties(String username, String password, String lastname, String permissionsFilePath) {
+public final class SystemUserProperties {
+
+  /**
+   * Defines if system-user functionality is enabled or not.
+   */
+  private boolean enabled = true;
+
+  /**
+   * System user username.
+   */
+  private String username;
+
+  /**
+   * System user password.
+   */
+  private String password;
+
+  /**
+   * System user lastname.
+   */
+  private String lastname;
+
+  /**
+   * Path to the system user permissions CSV file.
+   */
+  private String permissionsFilePath;
+
+  /**
+   * Constructor for 4 arguments: username, password, lastname and permissionsFilePath.
+   *
+   * @param username - system user username
+   * @param password - system user password
+   * @param lastname - system user lastname
+   * @param permissionsFilePath - path to the system user permissions CSV file
+   */
+  public SystemUserProperties(String username, String password, String lastname, String permissionsFilePath) {
+    this.username = username;
+    this.password = password;
+    this.lastname = lastname;
+    this.permissionsFilePath = permissionsFilePath;
+  }
+
+  /**
+   * Returns system user username.
+   *
+   * @return system user username as {@link String}
+   */
+  public String username() {
+    return username;
+  }
+
+  /**
+   * Returns system user password.
+   *
+   * @return system user password as {@link String}
+   */
+  public String password() {
+    return password;
+  }
+
+  /**
+   * Returns system user lastname.
+   *
+   * @return system user lastname as {@link String}
+   */
+  public String lastname() {
+    return lastname;
+  }
+
+  /**
+   * Returns path to the system user permissions CSV file.
+   *
+   * @return path to the system user permissions CSV file as {@link String}.
+   */
+  public String permissionsFilePath() {
+    return permissionsFilePath;
+  }
 }

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserProperties.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserProperties.java
@@ -4,6 +4,7 @@ import javax.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
@@ -49,6 +50,10 @@ public final class SystemUserProperties {
    * @param permissionsFilePath - path to the system user permissions CSV file
    */
   public SystemUserProperties(String username, String password, String lastname, String permissionsFilePath) {
+    if (StringUtils.isEmpty(password)) {
+      throw new IllegalArgumentException("system user password must be configured to be non-empty");
+    }
+
     this.username = username;
     this.password = password;
     this.lastname = lastname;

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserScopedExecutionService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserScopedExecutionService.java
@@ -6,6 +6,7 @@ import lombok.SneakyThrows;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.context.ExecutionContextBuilder;
 import org.folio.spring.scope.FolioExecutionContextSetter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +16,7 @@ public class SystemUserScopedExecutionService {
 
   private final FolioExecutionContext executionContext;
   private final ExecutionContextBuilder contextBuilder;
-  private final SystemUserService systemUserService;
+  private SystemUserService systemUserService;
 
   /**
    * Executes given action in scope of system user.
@@ -62,6 +63,13 @@ public class SystemUserScopedExecutionService {
   }
 
   private FolioExecutionContext folioExecutionContext(String tenantId) {
-    return contextBuilder.forSystemUser(systemUserService.getAuthedSystemUser(tenantId));
+    return systemUserService != null
+      ? contextBuilder.forSystemUser(systemUserService.getAuthedSystemUser(tenantId))
+      : contextBuilder.buildContext(tenantId);
+  }
+
+  @Autowired(required = false)
+  public void setSystemUserService(SystemUserService systemUserService) {
+    this.systemUserService = systemUserService;
   }
 }

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
@@ -21,11 +21,9 @@ import org.folio.spring.model.UserToken;
 import org.folio.spring.scope.FolioExecutionContextSetter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
 @Log4j2
-@Service
 @RequiredArgsConstructor
 public class SystemUserService {
 
@@ -50,7 +48,7 @@ public class SystemUserService {
 
   /**
    * Get authenticate system user.
-   * 
+   *
    * <p>Get from cache if present and is valid (not expired) for at least 30 seconds from now.
    * Otherwise call login expiry endpoint to get a new system user token.
    *

--- a/folio-spring-system-user/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/folio-spring-system-user/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
 org.folio.spring.config.SystemUserConfig
+org.folio.spring.config.OptionalSystemUserConfig

--- a/folio-spring-system-user/src/test/java/org/folio/spring/context/ExecutionContextBuilderTest.java
+++ b/folio-spring-system-user/src/test/java/org/folio/spring/context/ExecutionContextBuilderTest.java
@@ -2,16 +2,31 @@ package org.folio.spring.context;
 
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.config.properties.FolioEnvironment;
 import org.folio.spring.model.SystemUser;
 import org.folio.spring.model.UserToken;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class ExecutionContextBuilderTest {
 
-  private final ExecutionContextBuilder builder =
-      new ExecutionContextBuilder(mock(org.folio.spring.FolioModuleMetadata.class));
+  @InjectMocks private ExecutionContextBuilder builder;
+  @Mock private FolioModuleMetadata folioModuleMetadata;
+  @Mock private FolioEnvironment folioEnvironment;
+
+  @AfterEach
+  void tearDown() {
+    verifyNoMoreInteractions(folioModuleMetadata, folioEnvironment);
+  }
 
   @Test
   void canCreateSystemUserContextForSystemUser() {
@@ -50,5 +65,22 @@ class ExecutionContextBuilderTest {
     assertThat(context.getAllHeaders()).isNotNull();
     assertThat(context.getOkapiHeaders()).isNotNull().isEmpty();
     assertThat(context.getFolioModuleMetadata()).isNotNull();
+  }
+
+  @Test
+  void canCreateContextForDisabledSystemUser() {
+    var tenantId = "test-tenant";
+    var okapiUrl = "http://okapi:9130";
+    when(folioEnvironment.getOkapiUrl()).thenReturn(okapiUrl);
+
+    var context = builder.buildContext(tenantId);
+
+    assertThat(context.getTenantId()).isEqualTo(tenantId);
+    assertThat(context.getToken()).isEqualTo(EMPTY);
+    assertThat(context.getOkapiUrl()).isEqualTo(okapiUrl);
+
+    assertThat(context.getAllHeaders()).hasSize(2);
+    assertThat(context.getOkapiHeaders()).hasSize(2);
+    assertThat(context.getFolioModuleMetadata()).isEqualTo(folioModuleMetadata);
   }
 }

--- a/folio-spring-system-user/src/test/java/org/folio/spring/systemuser/PrepareSystemUserServiceTest.java
+++ b/folio-spring-system-user/src/test/java/org/folio/spring/systemuser/PrepareSystemUserServiceTest.java
@@ -40,7 +40,11 @@ class PrepareSystemUserServiceTest {
   private ArgumentCaptor<UsersClient.User> userArgumentCaptor;
 
   private static SystemUserProperties systemUserProperties() {
-    return new SystemUserProperties("username", "password", "system", "permissions/test-permissions.csv");
+    return systemUserProperties(true);
+  }
+
+  private static SystemUserProperties systemUserProperties(boolean enabled) {
+    return new SystemUserProperties(enabled, "username", "password", "system", "permissions/test-permissions.csv");
   }
 
   private static SystemUserProperties systemUserPropertiesWithoutPermissions() {
@@ -114,6 +118,12 @@ class PrepareSystemUserServiceTest {
       .addPermission(any(), eq(new Permission("inventory-storage.instance.item.post")));
   }
 
+  @Test
+  void shouldNotCreateSystemUserIfDisabled() {
+    prepareSystemUser(systemUserProperties(false));
+    verifyNoInteractions(authnClient, permissionsClient, usersClient);
+  }
+
   private ResultList<UsersClient.User> userExistsResponse() {
     return asSinglePage(new UsersClient.User("id", "username", SYSTEM_USER_TYPE, true,
       new Personal("lastName")));
@@ -124,7 +134,11 @@ class PrepareSystemUserServiceTest {
   }
 
   private PrepareSystemUserService systemUserService(SystemUserProperties properties) {
-    return new PrepareSystemUserService(usersClient, authnClient, permissionsClient, properties);
+    var prepareSystemUserService = new PrepareSystemUserService(properties);
+    prepareSystemUserService.setAuthnClient(authnClient);
+    prepareSystemUserService.setUsersClient(usersClient);
+    prepareSystemUserService.setPermissionsClient(permissionsClient);
+    return prepareSystemUserService;
   }
 
   private void prepareSystemUser(SystemUserProperties properties) {

--- a/folio-spring-system-user/src/test/java/org/folio/spring/systemuser/SystemUserScopedExecutionServiceTest.java
+++ b/folio-spring-system-user/src/test/java/org/folio/spring/systemuser/SystemUserScopedExecutionServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.concurrent.Callable;
@@ -14,6 +15,7 @@ import org.folio.spring.context.ExecutionContextBuilder;
 import org.folio.spring.model.SystemUser;
 import org.folio.spring.service.SystemUserScopedExecutionService;
 import org.folio.spring.service.SystemUserService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -34,12 +36,27 @@ class SystemUserScopedExecutionServiceTest {
   @Mock
   private FolioExecutionContext folioExecutionContext;
 
+  @BeforeEach
+  void setUp() {
+    systemUserScopedExecutionService.setSystemUserService(systemUserService);
+  }
+
   @Test
   void executeSystemUserScoped_positive() {
     var systemUser = SystemUser.builder().build();
     when(systemUserService.getAuthedSystemUser(TENANT_ID)).thenReturn(systemUser);
     when(contextBuilder.forSystemUser(systemUser)).thenReturn(new DefaultFolioExecutionContext(null, emptyMap()));
 
+    var actual = systemUserScopedExecutionService.executeSystemUserScoped(TENANT_ID, () -> "result");
+
+    assertThat(actual).isEqualTo("result");
+  }
+
+  @Test
+  void executeSystemUserScoped_positive_systemUserServiceIsNull() {
+    when(contextBuilder.buildContext(TENANT_ID)).thenReturn(new DefaultFolioExecutionContext(null, emptyMap()));
+
+    systemUserScopedExecutionService.setSystemUserService(null);
     var actual = systemUserScopedExecutionService.executeSystemUserScoped(TENANT_ID, () -> "result");
 
     assertThat(actual).isEqualTo("result");
@@ -58,12 +75,35 @@ class SystemUserScopedExecutionServiceTest {
   }
 
   @Test
+  void executeAsyncSystemUserScoped_positive_systemUserServiceIsNull() {
+    when(contextBuilder.buildContext(TENANT_ID)).thenReturn(new DefaultFolioExecutionContext(null, emptyMap()));
+    var runnableMock = mock(Runnable.class);
+
+    systemUserScopedExecutionService.setSystemUserService(null);
+    systemUserScopedExecutionService.executeAsyncSystemUserScoped(TENANT_ID, runnableMock);
+
+    verify(runnableMock).run();
+    verifyNoInteractions(systemUserService);
+  }
+
+  @Test
   void executeSystemUserScopedFromContext_positive() {
     var systemUser = SystemUser.builder().build();
     when(folioExecutionContext.getTenantId()).thenReturn(TENANT_ID);
     when(systemUserService.getAuthedSystemUser(TENANT_ID)).thenReturn(systemUser);
     when(contextBuilder.forSystemUser(systemUser)).thenReturn(new DefaultFolioExecutionContext(null, emptyMap()));
 
+    var actual = systemUserScopedExecutionService.executeSystemUserScoped(() -> "result");
+
+    assertThat(actual).isEqualTo("result");
+  }
+
+  @Test
+  void executeSystemUserScopedFromContext_positive_systemUserServiceIsNull() {
+    when(folioExecutionContext.getTenantId()).thenReturn(TENANT_ID);
+    when(contextBuilder.buildContext(TENANT_ID)).thenReturn(new DefaultFolioExecutionContext(null, emptyMap()));
+
+    systemUserScopedExecutionService.setSystemUserService(null);
     var actual = systemUserScopedExecutionService.executeSystemUserScoped(() -> "result");
 
     assertThat(actual).isEqualTo("result");

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>folio-spring-support</artifactId>
-  <version>7.3.0-SNAPSHOT</version>
+  <version>7.3.0-folspringb-128</version>
   <name>folio-spring-support</name>
   <description>This is a library (jar) that contains the basic functionality and main dependencies required for
     development FOLIO modules using


### PR DESCRIPTION
## Purpose
To support a proof of concept for improved provisioning and management of system users, implement the ability to disable the creation, management and use of system users in modules.

## Approach
- Implement a new configuration property: `folio.system-user.enabled`
- All actions called using `SystemUserScopedExecutionService` will be performed in `DefaultFolioExecutionContext`
- `X-Okapi-Token` header won't be populated with system user JWT token value
- Exclude non-required fields if system user functionality is disabled

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
