### PR TITLE
FOLSPRINGB-130: Spring Boot 3.1.5, Spring Cloud Openfeign 4.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.1</version> <!-- also change spring-boot.version -->
+    <version>3.1.5</version> <!-- also change spring-boot.version -->
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -27,8 +27,8 @@
 
   <properties>
     <java.version>17</java.version>
-    <spring-boot.version>3.1.1</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
-    <spring-cloud-starter-openfeign.version>4.0.3</spring-cloud-starter-openfeign.version>
+    <spring-boot.version>3.1.5</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
+    <spring-cloud-starter-openfeign.version>4.0.4</spring-cloud-starter-openfeign.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <maven-compat.version>3.9.2</maven-compat.version>


### PR DESCRIPTION
https://issues.folio.org/browse/FOLSPRINGB-130

Upgrade Spring Boot from 3.1.1 to 3.1.5. This indirectly upgrades tomcat-embed-core from 10.1.8 to 10.1.15 fixing Denial of Service (DoS), Access Restriction Bypass, Improper Input Validation, Incomplete Cleanup:

https://nvd.nist.gov/vuln/detail/CVE-2023-44487
https://nvd.nist.gov/vuln/detail/CVE-2023-41080
https://nvd.nist.gov/vuln/detail/CVE-2023-45648
https://nvd.nist.gov/vuln/detail/CVE-2023-42795

Upgrade spring-cloud-starter-openfeign from 4.0.3 to 4.0.4.

The spring-cloud-starter-openfeign upgrade indirectly upgrades commons-fileupload from 1.4 to 1.5 fixing Denial of Service (DoS):

https://nvd.nist.gov/vuln/detail/CVE-2023-24998

The spring-cloud-starter-openfeign upgrade indirectly removes the vulnerable dependency bcprov-jdk15on 1.69 fixing Information Exposure:

https://nvd.nist.gov/vuln/detail/CVE-2023-33201