### PR TITLE
FOLSPRINGB-145: Optimize related records count by Replacing "before count()" with "countDistinct()"

### DIFF
--- a/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
+++ b/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
@@ -90,7 +90,7 @@ public class Cql2JpaCriteria<E> {
       var cb = em.getCriteriaBuilder();
       var query = cb.createQuery(Long.class);
       var root = query.from(domainClass);
-      query.select(cb.count(root));
+      query.select(cb.countDistinct(root));
       var predicate = createPredicate(node, root, cb, query);
       query.orderBy(Collections.emptyList());
       root.getFetches().clear();


### PR DESCRIPTION
https://issues.folio.org/browse/FOLSPRINGB-145

# Description

## Issue
Initially, the criteria query used "before count()" to calculate related record counts for a parent entity, which led to incorrect counts due to the presence of duplicate parent IDs in the result set.

## Resolution:
In this pull request, I have optimized the criteria query by replacing the "before count()" method with "countDistinct()" to accurately count related records. This modification ensures that duplicate parent IDs no longer impact the count, resulting in more precise counts for related records.