### PR TITLE
fix(refresh-token-rotation): Use half of access token expiration as user cache expiration

### DIFF
--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
@@ -51,7 +51,7 @@ public class SystemUserService {
   /**
    * Get authenticate system user.
    *
-   * <p>Get from cache if present and is valid (not expired) for at least 30 seconds from now.
+   * <p>Get from cache if present and is valid (not expired).
    * Otherwise call login expiry endpoint to get a new system user token.
    *
    * @param tenantId The tenant name

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
@@ -50,7 +50,7 @@ public class SystemUserService {
 
   /**
    * Get authenticate system user.
-   * 
+   *
    * <p>Get from cache if present and is valid (not expired) for at least 30 seconds from now.
    * Otherwise call login expiry endpoint to get a new system user token.
    *
@@ -64,7 +64,7 @@ public class SystemUserService {
 
     var user = systemUserCache.get(tenantId, this::getSystemUser);
     var userToken = user.token();
-    if (userToken.accessTokenExpiration().isAfter(Instant.now().plusSeconds(30L))) {
+    if (userToken.accessTokenExpiration().isAfter(Instant.now())) {
       return user;
     }
 

--- a/folio-spring-system-user/src/main/java/org/folio/spring/utils/TokenUtils.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/utils/TokenUtils.java
@@ -33,6 +33,10 @@ public class TokenUtils {
         .build();
   }
 
+  /**
+   * Half of original token ttl is used as suggested for system users
+   * on <a href="https://wiki.folio.org/pages/viewpage.action?pageId=96414255">...</a>.
+   * */
   private Instant calculateTokenExpirationForUser(AuthnClient.LoginResponse loginResponse) {
     var tokenExpiration = parseExpiration(loginResponse.accessTokenExpiration());
     var now = Instant.now();

--- a/folio-spring-system-user/src/main/java/org/folio/spring/utils/TokenUtils.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/utils/TokenUtils.java
@@ -2,7 +2,9 @@ package org.folio.spring.utils;
 
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.ServerCookieDecoder;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.List;
 import lombok.experimental.UtilityClass;
@@ -27,8 +29,16 @@ public class TokenUtils {
 
     return UserToken.builder()
         .accessToken(accessToken)
-        .accessTokenExpiration(parseExpiration(loginResponse.accessTokenExpiration()))
+        .accessTokenExpiration(calculateTokenExpirationForUser(loginResponse))
         .build();
+  }
+
+  private Instant calculateTokenExpirationForUser(AuthnClient.LoginResponse loginResponse) {
+    var tokenExpiration = parseExpiration(loginResponse.accessTokenExpiration());
+    var now = Instant.now();
+    var customTtlMinutes = (long) Math.ceil(Duration.between(now, tokenExpiration).toMinutes() / 2.0);
+
+    return now.plus(customTtlMinutes, ChronoUnit.MINUTES);
   }
 
   private String getTokenFromCookies(String cookieName, List<Cookie> cookies) {


### PR DESCRIPTION
## Purpose
Fix "Invalid token" on system user operations
[FOLSPRINGB-132](https://issues.folio.org/browse/FOLSPRINGB-132)

## Approach
Use half of access token expiration as user cache expiration

## Learning
[RTR docs](https://wiki.folio.org/pages/viewpage.action?pageId=96414255) have a comment mentioning that new access token should be requested when half of ttl has passed