### PR TITLE
FOLSPRINGB-137: javadoc cannot find symbol onConstructor_

### DIFF
--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
@@ -20,7 +20,6 @@ import org.folio.spring.i18n.model.LanguageRegionPair;
 import org.folio.spring.i18n.model.TranslationFile;
 import org.folio.spring.i18n.model.TranslationMap;
 import org.folio.spring.i18n.model.TranslationMatchQuality;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.stereotype.Service;
@@ -35,7 +34,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
  */
 @Log4j2
 @Service
-@RequiredArgsConstructor(onConstructor_ = @Autowired)
+@RequiredArgsConstructor
 public class TranslationService {
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
           <executions>
             <execution>
               <id>attach-javadocs</id>
-              <phase>deploy</phase>
+              <phase>verify</phase>
               <goals>
                 <goal>jar</goal>
               </goals>


### PR DESCRIPTION
The attach-javadocs build phase fails:

https://jenkins-aws.indexdata.com/job/folio-org/job/folio-spring-support/job/master/27/execution/node/61/log/

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.5.0:jar (attach-javadocs) on project folio-spring-i18n: MavenReportException: Error while generating Javadoc:
[ERROR] Exit code: 1
[ERROR] /home/jenkins/workspace/_org_folio-spring-support_master/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java:38: error: cannot find symbol
[ERROR] @RequiredArgsConstructor(onConstructor_ = @Autowired)
[ERROR]                          ^
[ERROR]   symbol:   method onConstructor_()
[ERROR]   location: @interface RequiredArgsConstructor
```

As there is only one constructor Spring doesn't need the `@Autowired` and the `(onConstructor_ = @Autowired)` can be deleted. This fixes the javadoc syntax error and avoids delombok configuration.

In addition the attach-javadocs phase should run at the verify stage to fail the build when the pull request gets opened. Running it at the deploy phase fails after the merge, this is too late.