### PR TITLE
[FOLSPRINGB-138] Use more resilient method for translation module name extraction

### DIFF
--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
@@ -28,7 +28,11 @@ public record TranslationFile(List<Resource> resources) {
   private static final int MAX_FILENAME_PARTS = 2;
   private static final String JSON_FILE_SUFFIX = ".json";
 
+  // 125 -> sonar insists the below line is code
+  // 5852 -> sonar detected the regex as potentially vulnerable to ReDoS (backtracking)
+  //         this is not an issue as the regex is only used on known input from the module's classpath
   // accepts form of {something}[{something}/]{moduleName}/{anything}]{optional trailing}
+  @SuppressWarnings({"java:S125", "java:S5852"})
   private static final Pattern MODULE_NAME_FROM_DESCRIPTION_PATTERN = Pattern.compile(
     "^.*\\[(?:.*[\\/\\\\])?(?<moduleName>[^\\/\\\\]+)[\\/\\\\].*\\].*$"
   );
@@ -124,7 +128,9 @@ public record TranslationFile(List<Resource> resources) {
     if (parts[0].isBlank() && parts.length > 1) {
       throw log.throwing(
         new IllegalArgumentException(
-          "TranslationFile filename " + filename + " has a region but no language"
+          "TranslationFile filename " +
+          filename +
+          " has a region but no language"
         )
       );
     }
@@ -163,7 +169,8 @@ public record TranslationFile(List<Resource> resources) {
     if (!matcher.matches()) {
       throw log.throwing(
         new IllegalArgumentException(
-          "Could not extract module name from resource description " + description
+          "Could not extract module name from resource description " +
+          description
         )
       );
     }

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
@@ -29,8 +29,10 @@ public record TranslationFile(List<Resource> resources) {
   private static final String JSON_FILE_SUFFIX = ".json";
 
   // 125 -> sonar insists the comment is code
+  // 5852 -> sonar detected the regex as potentially vulnerable to ReDoS (backtracking)
+  //         this is not an issue as the regex is only used on known input from the module's classpath
   // accepts form of {something}[{something}/]{moduleName}/{anything}]{optional trailing}
-  @SuppressWarnings({ "java:S125" })
+  @SuppressWarnings({ "java:S125", "java:S5852" })
   private static final Pattern MODULE_NAME_FROM_DESCRIPTION_PATTERN = Pattern.compile(
     ".*[\\[/\\\\](?<moduleName>[^/\\\\]+)[/\\\\].*"
   );

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
@@ -28,13 +28,11 @@ public record TranslationFile(List<Resource> resources) {
   private static final int MAX_FILENAME_PARTS = 2;
   private static final String JSON_FILE_SUFFIX = ".json";
 
-  // 125 -> sonar insists the below line is code
-  // 5852 -> sonar detected the regex as potentially vulnerable to ReDoS (backtracking)
-  //         this is not an issue as the regex is only used on known input from the module's classpath
+  // 125 -> sonar insists the comment is code
   // accepts form of {something}[{something}/]{moduleName}/{anything}]{optional trailing}
-  @SuppressWarnings({"java:S125", "java:S5852"})
+  @SuppressWarnings({ "java:S125" })
   private static final Pattern MODULE_NAME_FROM_DESCRIPTION_PATTERN = Pattern.compile(
-    "^.*\\[(?:.*[\\/\\\\])?(?<moduleName>[^\\/\\\\]+)[\\/\\\\].*\\].*$"
+    ".*[\\[/\\\\](?<moduleName>[^/\\\\]+)[/\\\\].*"
   );
 
   /**

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
@@ -128,9 +128,7 @@ public record TranslationFile(List<Resource> resources) {
     if (parts[0].isBlank() && parts.length > 1) {
       throw log.throwing(
         new IllegalArgumentException(
-          "TranslationFile filename " +
-          filename +
-          " has a region but no language"
+          "TranslationFile filename " + filename + " has a region but no language"
         )
       );
     }
@@ -169,8 +167,7 @@ public record TranslationFile(List<Resource> resources) {
     if (!matcher.matches()) {
       throw log.throwing(
         new IllegalArgumentException(
-          "Could not extract module name from resource description " +
-          description
+          "Could not extract module name from resource description " + description
         )
       );
     }

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
@@ -30,7 +30,7 @@ public record TranslationFile(List<Resource> resources) {
 
   // accepts form of {something}[{something}/]{moduleName}/{anything}]{optional trailing}
   private static final Pattern MODULE_NAME_FROM_DESCRIPTION_PATTERN = Pattern.compile(
-    ".*\\[(?:.*[\\/\\\\])?(?<moduleName>[^\\/\\\\]+)[\\/\\\\].*\\].*"
+    "^.*\\[(?:.*[\\/\\\\])?(?<moduleName>[^\\/\\\\]+)[\\/\\\\].*\\].*$"
   );
 
   /**

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
@@ -37,6 +37,11 @@ public record TranslationFile(List<Resource> resources) {
 
     for (Resource resource : resources) {
       try {
+        log.info("resource.getFilename(): {}", resource.getFilename());
+        log.info("resource.getDescription(): {}", resource.getDescription());
+        log.info("resource.getUri(): {}", resource.getURI());
+        log.info("resource.getUrl(): {}", resource.getURL());
+
         Map<String, String> moduleMap = objectMapper.readValue(
           resource.getInputStream(),
           new TypeReference<>() {}

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationFile.java
@@ -30,7 +30,7 @@ public record TranslationFile(List<Resource> resources) {
 
   // accepts form of {something}[{something}/]{moduleName}/{anything}]{optional trailing}
   private static final Pattern MODULE_NAME_FROM_DESCRIPTION_PATTERN = Pattern.compile(
-    ".*\\[(?:.*\\/)?(?<moduleName>[^\\/]+)\\/.*\\].*"
+    ".*\\[(?:.*[\\/\\\\])?(?<moduleName>[^\\/\\\\]+)[\\/\\\\].*\\].*"
   );
 
   /**

--- a/folio-spring-i18n/src/test/java/org/folio/spring/i18n/model/TranslationFileLanguageExtractionTest.java
+++ b/folio-spring-i18n/src/test/java/org/folio/spring/i18n/model/TranslationFileLanguageExtractionTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.core.io.FileSystemResource;
 
-class TranslationFileNameExtractionTest {
+class TranslationFileLanguageExtractionTest {
 
   static List<Arguments> fullExtractionCases() {
     return Arrays.asList(

--- a/folio-spring-i18n/src/test/java/org/folio/spring/i18n/model/TranslationFileModuleExtractionTest.java
+++ b/folio-spring-i18n/src/test/java/org/folio/spring/i18n/model/TranslationFileModuleExtractionTest.java
@@ -1,0 +1,60 @@
+package org.folio.spring.i18n.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TranslationFileModuleExtractionTest {
+
+  static List<Arguments> extractionCases() {
+    return Arrays.asList(
+      arguments("file [/foo/bar/baz/mod-something/en.json]", "mod-something"),
+      arguments("file [foo/bar/baz/mod-something/en.json]", "mod-something"),
+      arguments("file [mod-test/en.json]", "mod-test"),
+      arguments("file [mod-test/something-else]", "mod-test"),
+      arguments("file [mod-foo/mod-bar/mod-test/mod-other]", "mod-test"),
+      arguments(
+        "class path resource [mod-foo/mod-bar/mod-test/mod-other]",
+        "mod-test"
+      ),
+      arguments("file [C:/Test/translations/mod-test/mod-other]", "mod-test")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource({ "extractionCases" })
+  void testModuleNameExtraction(String description, String expectedModuleName) {
+    assertThat(
+      description + " parses to " + expectedModuleName,
+      TranslationFile.getModuleNameFromResourceDescription(description),
+      is(expectedModuleName)
+    );
+  }
+
+  static List<Arguments> invalidExtractionCases() {
+    return Arrays.asList(
+      arguments("file []"),
+      arguments("not a thing"),
+      arguments("missing the brackets translations/mod-foo/bar.json"),
+      arguments("[en.json]"),
+      arguments("")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("invalidExtractionCases")
+  void testInvalidModuleNameExtraction(String filename) {
+    assertThrows(
+      IllegalArgumentException.class,
+      () -> TranslationFile.getModuleNameFromResourceDescription(filename),
+      "Filenames with more than two components are invalid"
+    );
+  }
+}

--- a/folio-spring-i18n/src/test/java/org/folio/spring/i18n/model/TranslationFileModuleExtractionTest.java
+++ b/folio-spring-i18n/src/test/java/org/folio/spring/i18n/model/TranslationFileModuleExtractionTest.java
@@ -50,7 +50,6 @@ class TranslationFileModuleExtractionTest {
     return Arrays.asList(
       arguments("file []"),
       arguments("not a thing"),
-      arguments("missing the brackets translations/mod-foo/bar.json"),
       arguments("[en.json]"),
       arguments("")
     );

--- a/folio-spring-i18n/src/test/java/org/folio/spring/i18n/model/TranslationFileModuleExtractionTest.java
+++ b/folio-spring-i18n/src/test/java/org/folio/spring/i18n/model/TranslationFileModuleExtractionTest.java
@@ -24,7 +24,15 @@ class TranslationFileModuleExtractionTest {
         "class path resource [mod-foo/mod-bar/mod-test/mod-other]",
         "mod-test"
       ),
-      arguments("file [C:/Test/translations/mod-test/mod-other]", "mod-test")
+      arguments("file [C:/Test/translations/mod-test/mod-other]", "mod-test"),
+      arguments(
+        "file [C:\\Test\\translations\\mod-test\\mod-other]",
+        "mod-test"
+      ),
+      arguments(
+        "class path resource [translations\\mod-test\\mod-other]",
+        "mod-test"
+      )
     );
   }
 


### PR DESCRIPTION
# [Jira FOLSPRINGB-138](https://issues.folio.org/browse/FOLSPRINGB-138)

## Purpose
The existing solution to extract module names from translation file paths would fail under certain conditions when run in JAR files.

## Approach
This uses the more resilient resource description, as opposed to assuming a filename is present and able to be parsed.

In local testing, this description seemed to be the best option:
- `getFilename` only returns the last part (e.g. `en.json`) which is useless for this
- `getFile` assumes that a file exists, which may not be the case in JARs (our original error)
- `getURL` and `getURI` seem promising, however, we [originally tried this and it caused errors on Windows](https://github.com/folio-org/folio-spring-support/pull/122#pullrequestreview-1735346063) where Spring had trouble converting `C:\` into a legal URI that could then be decoded, since technically `:` is not valid in a URI
- This leaves `getDescription`

Here's what these looked like in our tests:
#### Unix-style paths, running locally/in maven
```
resource.getFilename(): es.json
resource.getDescription(): file [/Users/novercash/folio/folio-spring-base/folio-spring-i18n/target/test-classes/test-translations/test-multiple/mod-bar/es.json]
resource.getUri(): file:/Users/novercash/folio/folio-spring-base/folio-spring-i18n/target/test-classes/test-translations/test-multiple/mod-bar/es.json
resource.getUrl(): file:/Users/novercash/folio/folio-spring-base/folio-spring-i18n/target/test-classes/test-translations/test-multiple/mod-bar/es.json
```

#### Unix-style paths, running in a jar
```
resource.getFilename(): en.json
resource.getDescription(): class path resource [translations/mod-fqm-manager/en.json]
resource.getUri(): jar:file:/Users/novercash/folio/mod-fqm-manager/target/mod-fqm-manager-1.0.4-SNAPSHOT.jar!/BOOT-INF/classes!/translations/mod-fqm-manager/en.json
resource.getUrl(): jar:file:/Users/novercash/folio/mod-fqm-manager/target/mod-fqm-manager-1.0.4-SNAPSHOT.jar!/BOOT-INF/classes!/translations/mod-fqm-manager/en.json
```

#### Windows, running locally/in maven
```
resource.getFilename(): en.json
resource.getDescription(): file [C:\Users\Temp\Downloads\noah temp\folio-spring-support\folio-spring-i18n\target\test-classes\test-translations\test-multiple\mod-foo\en.json]
resource.getUri(): file:/C:/Users/Temp/Downloads/noah%20temp/folio-spring-support/folio-spring-i18n/target/test-classes/test-translations/test-multiple/mod-foo/en.json
resource.getUrl(): file:/C:/Users/Temp/Downloads/noah%20temp/folio-spring-support/folio-spring-i18n/target/test-classes/test-translations/test-multiple/mod-foo/en.json
```

#### Windows, running in a jar
```
resource.getFilename(): en_US.json
resource.getDescription(): class path resource [translations/mod-calendar/en_US.json]
resource.getUri(): jar:file:/C:/Users/Temp/Downloads/noah%20temp/mod-calendar/target/mod-calendar-2.6.0-SNAPSHOT.jar!/BOOT-INF/classes!/translations/mod-calendar/en_US.json
resource.getUrl(): jar:file:/C:/Users/Temp/Downloads/noah%20temp/mod-calendar/target/mod-calendar-2.6.0-SNAPSHOT.jar!/BOOT-INF/classes!/translations/mod-calendar/en_US.json
```

