### PR TITLE
FOLSPRINGB-141: Upgrade deps for Quesnelia: Spring Boot 3.2.0, …

### DIFF
--- a/folio-spring-base/pom.xml
+++ b/folio-spring-base/pom.xml
@@ -53,7 +53,6 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-openfeign</artifactId>
-      <version>${spring-cloud-starter-openfeign.version}</version>
     </dependency>
 
     <dependency>
@@ -70,33 +69,18 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <!-- spring-boot-starter-parent provides an old org.postgresql:postgresql version,
-           we need the fix that closes the socket and the fix for hanging ssl connections:
-           https://jdbc.postgresql.org/changelogs/2023-01-31-42.5.2-release/#fixed
-      -->
-      <version>${postgresql.version}</version>
       <scope>runtime</scope>
     </dependency>
 
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
-      <version>${liquibase-core.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.github.openfeign</groupId>
       <artifactId>feign-okhttp</artifactId>
       <version>${feign-okhttp.version}</version>
-    </dependency>
-
-    <!-- fixes https://nvd.nist.gov/vuln/detail/CVE-2023-3635
-         remove when okhttp ships with okio-jvm >= 3.4.0 -->
-    <dependency>
-      <groupId>com.squareup.okio</groupId>
-      <artifactId>okio-jvm</artifactId>
-      <version>3.4.0</version>
-      <scope>runtime</scope>
     </dependency>
 
     <!-- OAS generation -->
@@ -110,13 +94,6 @@
           <artifactId>slf4j-simple</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <dependency>
-      <!-- Needed as long as openapi-generator ships with a vulnerable guava version (< 32.0.0-jre) https://nvd.nist.gov/vuln/detail/CVE-2023-2976 -->
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
     </dependency>
 
     <dependency>

--- a/folio-spring-base/src/main/java/org/folio/spring/liquibase/FolioLiquibaseConfiguration.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/liquibase/FolioLiquibaseConfiguration.java
@@ -41,7 +41,7 @@ public class FolioLiquibaseConfiguration {
     liquibase.setDatabaseChangeLogLockTable(this.properties.getDatabaseChangeLogLockTable());
     liquibase.setDropFirst(this.properties.isDropFirst());
     liquibase.setShouldRun(this.properties.isEnabled());
-    liquibase.setLabels(this.properties.getLabels());
+    liquibase.setLabelFilter(this.properties.getLabelFilter());
     liquibase.setChangeLogParameters(this.properties.getParameters());
     liquibase.setRollbackFile(this.properties.getRollbackFile());
     liquibase.setTestRollbackOnUpdate(this.properties.isTestRollbackOnUpdate());

--- a/folio-spring-base/src/main/java/org/folio/spring/service/TenantService.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/service/TenantService.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.BooleanUtils.isTrue;
 
 import java.sql.ResultSet;
 import liquibase.exception.LiquibaseException;
+import liquibase.exception.UnexpectedLiquibaseException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.spring.FolioExecutionContext;
@@ -48,7 +49,7 @@ public class TenantService {
 
       try {
         folioSpringLiquibase.performLiquibaseUpdate();
-      } catch (LiquibaseException e) {
+      } catch (LiquibaseException | UnexpectedLiquibaseException e) {
         throw new TenantUpgradeException(e);
       }
 

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
@@ -15,6 +15,7 @@ import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -380,7 +381,7 @@ public class Cql2JpaCriteria<E> {
       term = UUID.fromString((String) term);
     } else if (Boolean.class.equals(javaType)) {
       term = Boolean.valueOf((String) term);
-    } else if (Date.class.equals(javaType)) {
+    } else if (Date.class.equals(javaType) || Timestamp.class.equals(javaType)) {
       var value = (String) term;
       if (isDatesRange(value)) {
         return toFilterByDatesPredicate(field, value, cb);

--- a/folio-spring-system-user/pom.xml
+++ b/folio-spring-system-user/pom.xml
@@ -12,13 +12,6 @@
   <artifactId>folio-spring-system-user</artifactId>
   <description />
 
-  <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-    <edge-api-utils-version>1.2.0</edge-api-utils-version>
-    <testcontainers.version>1.17.6</testcontainers.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.folio</groupId>
@@ -70,7 +63,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.1.5</version> <!-- also change spring-boot.version -->
+    <version>3.2.0</version> <!-- also change spring-boot.version -->
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -28,42 +28,28 @@
 
   <properties>
     <java.version>17</java.version>
-    <spring-boot.version>3.1.5</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
-    <spring-cloud-starter-openfeign.version>4.0.4</spring-cloud-starter-openfeign.version>
-    <snakeyaml.version>2.0</snakeyaml.version>
-    <commons-lang3.version>3.12.0</commons-lang3.version>
-    <maven-compat.version>3.9.2</maven-compat.version>
+    <spring-boot.version>3.2.0</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
+    <spring-cloud-starter-openfeign.version>4.1.0</spring-cloud-starter-openfeign.version>
+    <maven-compat.version>3.9.6</maven-compat.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
-    <swagger-annotations.version>2.2.10</swagger-annotations.version>
-    <feign-okhttp.version>12.3</feign-okhttp.version>
-    <lombok.version>1.18.28</lombok.version>
+    <swagger-annotations.version>2.2.19</swagger-annotations.version>
+    <feign-okhttp.version>13.1</feign-okhttp.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
-    <cql2pgjson.version>35.1.0</cql2pgjson.version>
-    <postgresql.version>42.6.0</postgresql.version>
-    <liquibase-core.version>4.22.0</liquibase-core.version>
+    <cql2pgjson.version>35.1.1</cql2pgjson.version>
+    <edge-api-utils-version>1.3.0</edge-api-utils-version>
     <rhino.version>1.7.14</rhino.version>
-    <icu4j.version>74.1</icu4j.version>
+    <icu4j.version>74.2</icu4j.version>
 
     <!-- Test dependencies versions -->
     <easy-random.version>5.0.0</easy-random.version>
-    <embedded-database-spring-test.version>2.3.0</embedded-database-spring-test.version>
-    <embedded-postgres.version>2.0.4</embedded-postgres.version>
+    <embedded-database-spring-test.version>2.4.0</embedded-database-spring-test.version>
+    <embedded-postgres.version>2.0.6</embedded-postgres.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
 
     <!-- Plugins versions -->
-    <versions-maven-plugin.version>2.15.0</versions-maven-plugin.version>
-    <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
-    <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
-    <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
-    <maven-checkstyle-plugin.version>3.2.2</maven-checkstyle-plugin.version>
-    <openapi-generator.version>6.6.0</openapi-generator.version>
-    <guava.version>32.1.1-jre</guava.version>  <!-- remove when openapi-generator ships with non-vulnerable guava >= 32.0.0 -->
-    <maven-failsafe-plugin.version>3.1.0</maven-failsafe-plugin.version>
-    <maven-release-plugin.version>3.0.0</maven-release-plugin.version>
-    <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
-    <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
-    <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
-    <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+    <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
+    <openapi-generator.version>7.1.0</openapi-generator.version>
+    <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -86,6 +72,12 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-starter-openfeign</artifactId>
+        <version>${spring-cloud-starter-openfeign.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -116,15 +108,6 @@
         </plugin>
 
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>versions-maven-plugin</artifactId>
-          <version>${versions-maven-plugin.version}</version>
-          <configuration>
-            <generateBackupPoms>false</generateBackupPoms>
-          </configuration>
-        </plugin>
-
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
           <version>${maven-enforcer-plugin.version}</version>
@@ -143,51 +126,6 @@
               </configuration>
             </execution>
           </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>build-helper-maven-plugin</artifactId>
-          <version>${build-helper-maven-plugin.version}</version>
-          <executions>
-            <execution>
-              <phase>generate-sources</phase>
-              <goals>
-                <goal>add-source</goal>
-              </goals>
-              <configuration>
-                <sources>
-                  <source>${project.build.directory}/generated-sources</source>
-                </sources>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>${maven-compiler-plugin.version}</version>
-          <configuration>
-            <release>${java.version}</release>
-            <annotationProcessorPaths>
-              <path>
-                <groupId>org.projectlombok</groupId>
-                <artifactId>lombok</artifactId>
-                <version>${lombok.version}</version>
-              </path>
-              <path>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-configuration-processor</artifactId>
-                <version>${spring-boot.version}</version>
-              </path>
-              <path>
-                <groupId>org.mapstruct</groupId>
-                <artifactId>mapstruct-processor</artifactId>
-                <version>${mapstruct.version}</version>
-              </path>
-            </annotationProcessorPaths>
-          </configuration>
         </plugin>
 
         <plugin>
@@ -242,57 +180,6 @@
           </configuration>
         </plugin>
 
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${maven-failsafe-plugin.version}</version>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-source-plugin</artifactId>
-          <version>${maven-source-plugin.version}</version>
-          <executions>
-            <execution>
-              <id>attach-sources</id>
-              <phase>deploy</phase>
-              <goals>
-                <goal>jar-no-fork</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <version>${maven-javadoc-plugin.version}</version>
-          <executions>
-            <execution>
-              <id>attach-javadocs</id>
-              <phase>verify</phase>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>${maven-deploy-plugin.version}</version>
-          <executions>
-            <execution>
-              <id>deploy</id>
-              <phase>deploy</phase>
-              <goals>
-                <goal>deploy</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-
       </plugins>
     </pluginManagement>
 
@@ -305,19 +192,70 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
+        <configuration>
+          <generateBackupPoms>false</generateBackupPoms>
+        </configuration>
       </plugin>
 
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireMavenVersion>
+                  <version>3.6.3</version>
+                </requireMavenVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <release>${java.version}</release>
+            <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>${lombok.version}</version>
+            </path>
+            <path>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-configuration-processor</artifactId>
+              <version>${spring-boot.version}</version>
+            </path>
+            <path>
+              <groupId>org.mapstruct</groupId>
+              <artifactId>mapstruct-processor</artifactId>
+              <version>${mapstruct.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
       </plugin>
 
       <plugin>
@@ -334,14 +272,41 @@
 
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>deploy</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>deploy</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
https://issues.folio.org/browse/FOLSPRINGB-141

Upgrade dependencies for Quesnelia, see https://wiki.folio.org/display/TC/Quesnelia

Upgrade Spring Boot from 3.1.5 to 3.2.0.
Many other dependency versions are provided by Spring Boot: https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/3.2.0/spring-boot-dependencies-3.2.0.pom
By dynamically using the Spring Boot provided versions we avoid hard-coding them in our pom.xml and no longer need to manually bump them. Therefore these hard-coded dependency versions can be removed:

* snakeyaml
* commons-lang3
* lombok
* postgresql
* liquibase
* testcontainers
* versions-maven-plugin
* maven-enforcer-plugin
* build-helper-maven-plugin
* maven-compiler-plugin
* maven-failsafe-plugin
* maven-surefire-plugin
* maven-javadoc-plugin
* maven-deploy-plugin

Upgrading liquibase from 4.22.0 to (Spring Boot provided) 4.24.0 requires two small code changes.

Upgrading Jpa requires a small Date/Timestamp code change.

Upgrading OpenAPI from 6.6.0 to 7.1.0 fixes https://issues.folio.org/browse/FOLSPRINGB-125