### PR TITLE
FOLSPRINGB-142: Add support for Timestamp type field in Cql query

### DIFF
--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
@@ -15,6 +15,7 @@ import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -380,7 +381,7 @@ public class Cql2JpaCriteria<E> {
       term = UUID.fromString((String) term);
     } else if (Boolean.class.equals(javaType)) {
       term = Boolean.valueOf((String) term);
-    } else if (Date.class.equals(javaType)) {
+    } else if (Date.class.equals(javaType) || Timestamp.class.equals(javaType)) {
       var value = (String) term;
       if (isDatesRange(value)) {
         return toFilterByDatesPredicate(field, value, cb);

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
@@ -138,7 +138,8 @@ class JpaCqlRepositoryIT {
     "3, 0, -1"
   })
   void testSelectAllRecordsWithSortAndPagination(int pageNumber, int size, int age) {
-    var page = personRepository.findByCql("(cql.allRecords=1)sortby age/sort.descending", PageRequest.of(pageNumber, 1));
+    var page = personRepository.findByCql("(cql.allRecords=1)sortby age/sort.descending",
+      PageRequest.of(pageNumber, 1));
 
     if (size == 0) {
       assertThat(page)

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/domain/Person.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/domain/Person.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.UUID;
@@ -27,6 +28,7 @@ public class Person {
   private Date dateBorn;
   private LocalDateTime localDate;
   private boolean deleted = false;
+  private Timestamp createdDate;
 
   @ManyToOne
   @JoinColumn(name = "city_id")

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-general-it-schema.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-general-it-schema.sql
@@ -4,5 +4,5 @@ DROP TABLE IF EXISTS
   str;
 
 CREATE TABLE city(id INT PRIMARY KEY, name VARCHAR(255));
-CREATE TABLE person(id INT PRIMARY KEY, name VARCHAR(255), age INT, identifier UUID, is_alive boolean, date_born timestamp, local_date timestamp, city_id INT REFERENCES city(id), deleted boolean);
+CREATE TABLE person(id INT PRIMARY KEY, name VARCHAR(255), age INT, identifier UUID, is_alive boolean, date_born timestamp, local_date timestamp, city_id INT REFERENCES city(id), deleted boolean, created_date timestamp);
 CREATE TABLE str(id INT PRIMARY KEY, str text);

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-general-test-data.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-general-test-data.sql
@@ -1,9 +1,9 @@
 insert into city(id, name) values (1, 'Kharkiv');
 insert into city(id, name) values (2, 'Kyiv');
 
-insert into person(id, name, age, city_id, date_born, local_date, deleted) values (101, 'Jane', 20, 1, '2001-01-03', '2001-01-03', false);
-insert into person(id, name, age, city_id, date_born, local_date, deleted) values (102, 'John', 22, 2, '2001-01-01', '2001-01-01', false);
-insert into person(id, name, age, city_id, date_born, local_date, deleted) values (103, 'John', 40, 1, '2001-01-02', '2001-01-02', false);
+insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (101, 'Jane', 20, 1, '2001-01-03', '2001-01-03', false, '2021-12-20T06:31:31+05:00');
+insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (102, 'John', 22, 2, '2001-01-01', '2001-01-01', false, '2021-12-25T06:31:31+05:00');
+insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (103, 'John', 40, 1, '2001-01-02', '2001-01-02', false, '2021-12-31T06:31:31+05:00');
 
 insert into str(id, str) values
   (1, 'a'),

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-person-test-data.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-person-test-data.sql
@@ -1,4 +1,4 @@
-insert into person(id, name, age, city_id, date_born, local_date, deleted) values (104, 'Jane', 26, 1, '2001-01-03', '2001-01-03', false);
-insert into person(id, name, age, city_id, date_born, local_date, deleted) values (105, 'John', 30, 1, '2001-01-02', '2001-01-02', false);
-insert into person(id, name, age, city_id, date_born, local_date, deleted) values (106, 'Jane', 32, 1, '2001-01-03', '2001-01-03', true);
-insert into person(id, name, age, city_id, date_born, local_date, deleted) values (107, 'John', 33, 1, '2001-01-02', '2001-01-02', true);
+insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (104, 'Jane', 26, 1, '2001-01-03', '2001-01-03', false, '2021-12-25T06:31:31+05:00');
+insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (105, 'John', 30, 1, '2001-01-02', '2001-01-02', false, '2021-12-25T06:31:31+05:00');
+insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (106, 'Jane', 32, 1, '2001-01-03', '2001-01-03', true, '2021-12-25T06:31:31+05:00');
+insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (107, 'John', 33, 1, '2001-01-02', '2001-01-02', true, '2021-12-25T06:31:31+05:00');


### PR DESCRIPTION
## Purpose
_Add possibility to specify fields in Cql query which are of Timestamp type._

## Approach
Include Timestamp type to be checked when parsing cql query term from String.

## Learning
Closes: [FOLSPRINGB-142](https://issues.folio.org/browse/FOLSPRINGB-142)
