### PR TITLE
[FOLSPRINGB-139] Pass Accept-Language header in Feign clients

### DIFF
--- a/folio-spring-base/src/main/java/org/folio/spring/client/EnrichUrlAndHeadersClient.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/client/EnrichUrlAndHeadersClient.java
@@ -9,7 +9,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.log4j.Log4j2;
-
 import org.apache.commons.lang3.StringUtils;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.http.HttpHeaders;

--- a/folio-spring-base/src/main/java/org/folio/spring/client/EnrichUrlAndHeadersClient.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/client/EnrichUrlAndHeadersClient.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.log4j.Log4j2;
 import org.folio.spring.FolioExecutionContext;
+import org.springframework.http.HttpHeaders;
 
 @Log4j2
 public class EnrichUrlAndHeadersClient implements Client {
@@ -68,10 +69,10 @@ public class EnrichUrlAndHeadersClient implements Client {
 
     // add accept-language header, if one exists
     context.getAllHeaders().keySet().stream()
-      .filter("Accept-Language"::equalsIgnoreCase)
+      .filter(HttpHeaders.ACCEPT_LANGUAGE::equalsIgnoreCase)
       .findFirst()
       .map(key -> context.getAllHeaders().get(key))
-      .ifPresent(values -> allHeaders.put("Accept-Language", values));
+      .ifPresent(values -> allHeaders.put(HttpHeaders.ACCEPT_LANGUAGE, values));
 
     return allHeaders;
   }

--- a/folio-spring-base/src/main/java/org/folio/spring/client/EnrichUrlAndHeadersClient.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/client/EnrichUrlAndHeadersClient.java
@@ -68,7 +68,7 @@ public class EnrichUrlAndHeadersClient implements Client {
 
     // add accept-language header, if one exists
     context.getAllHeaders().keySet().stream()
-      .filter(key -> "Accept-Language".equalsIgnoreCase(key))
+      .filter("Accept-Language"::equalsIgnoreCase)
       .findFirst()
       .map(key -> context.getAllHeaders().get(key))
       .ifPresent(values -> allHeaders.put("Accept-Language", values));

--- a/folio-spring-base/src/main/java/org/folio/spring/client/EnrichUrlAndHeadersClient.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/client/EnrichUrlAndHeadersClient.java
@@ -9,6 +9,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.extern.log4j.Log4j2;
+
+import org.apache.commons.lang3.StringUtils;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.http.HttpHeaders;
 
@@ -56,9 +58,7 @@ public class EnrichUrlAndHeadersClient implements Client {
       return requestUrl;
     }
 
-    if (!okapiUrl.endsWith("/")) {
-      okapiUrl += "/";
-    }
+    okapiUrl = StringUtils.appendIfMissing(okapiUrl, "/");
 
     return requestUrl.replace("http://", okapiUrl);
   }

--- a/folio-spring-base/src/main/java/org/folio/spring/client/EnrichUrlAndHeadersClient.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/client/EnrichUrlAndHeadersClient.java
@@ -48,7 +48,7 @@ public class EnrichUrlAndHeadersClient implements Client {
     return delegate.execute(requestWithUrl, options);
   }
 
-  protected static String prepareUrl(String requestUrl, FolioExecutionContext context) {
+  static String prepareUrl(String requestUrl, FolioExecutionContext context) {
     String okapiUrl = context.getOkapiUrl();
 
     if (okapiUrl == null) {
@@ -62,7 +62,7 @@ public class EnrichUrlAndHeadersClient implements Client {
     return requestUrl.replace("http://", okapiUrl);
   }
 
-  protected static Map<String, Collection<String>> prepareHeaders(Request request, FolioExecutionContext context) {
+  static Map<String, Collection<String>> prepareHeaders(Request request, FolioExecutionContext context) {
     Map<String, Collection<String>> allHeaders = new HashMap<>(request.headers());
     allHeaders.putAll(context.getOkapiHeaders());
 

--- a/folio-spring-base/src/test/java/org/folio/spring/client/EnrichUrlAndHeadersClientTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/client/EnrichUrlAndHeadersClientTest.java
@@ -17,7 +17,6 @@ import feign.Request;
 import feign.Response;
 import feign.okhttp.OkHttpClient;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.folio.spring.FolioExecutionContext;
@@ -33,7 +32,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 class EnrichUrlAndHeadersClientTest {
 
   static List<Arguments> urlPreparationCases() {
-    return Arrays.asList(
+    return List.of(
       arguments("http://test-url", null, "http://test-url"),
       arguments("http://test-url", "http://okapi", "http://okapi/test-url"),
       arguments("http://test-url", "http://okapi/", "http://okapi/test-url")

--- a/folio-spring-base/src/test/java/org/folio/spring/client/EnrichUrlAndHeadersClientTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/client/EnrichUrlAndHeadersClientTest.java
@@ -58,12 +58,9 @@ class EnrichUrlAndHeadersClientTest {
     when(request.headers())
       .thenReturn(
         Map.of(
-          "a",
-          List.of("a-val"),
-          "b",
-          List.of("b-val"),
-          "c",
-          List.of("c-val")
+          "a", List.of("a-val"),
+          "b", List.of("b-val"),
+          "c", List.of("c-val")
         )
       );
 
@@ -94,12 +91,9 @@ class EnrichUrlAndHeadersClientTest {
     when(request.headers())
       .thenReturn(
         Map.of(
-          "a",
-          List.of("a-val"),
-          "b",
-          List.of("b-val"),
-          "c",
-          List.of("c-val")
+          "a", List.of("a-val"),
+          "b", List.of("b-val"),
+          "c", List.of("c-val")
         )
       );
 
@@ -108,12 +102,9 @@ class EnrichUrlAndHeadersClientTest {
     when(context.getAllHeaders())
       .thenReturn(
         Map.of(
-          "misc-1",
-          List.of("misc-1-val"),
-          "accept-language",
-          List.of("en-US,en;q=0.9"),
-          "misc-2",
-          List.of("misc-2-val")
+          "misc-1", List.of("misc-1-val"),
+          "accept-language", List.of("en-US,en;q=0.9"),
+          "misc-2", List.of("misc-2-val")
         )
       );
 
@@ -148,12 +139,9 @@ class EnrichUrlAndHeadersClientTest {
     when(context.getAllHeaders())
       .thenReturn(
         Map.of(
-          "misc-1",
-          List.of("misc-1-val"),
-          "accept-language",
-          List.of("en-US,en;q=0.9"),
-          "misc-2",
-          List.of("misc-2-val")
+          "misc-1", List.of("misc-1-val"),
+          "accept-language", List.of("en-US,en;q=0.9"),
+          "misc-2", List.of("misc-2-val")
         )
       );
 

--- a/folio-spring-base/src/test/java/org/folio/spring/client/EnrichUrlAndHeadersClientTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/client/EnrichUrlAndHeadersClientTest.java
@@ -6,10 +6,17 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import feign.Request;
+import feign.Response;
+import feign.okhttp.OkHttpClient;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @UnitTest
 class EnrichUrlAndHeadersClientTest {
@@ -118,6 +127,73 @@ class EnrichUrlAndHeadersClientTest {
           hasEntry("z", List.of("z-val")),
           hasEntry("Accept-Language", List.of("en-US,en;q=0.9")),
           is(aMapWithSize(5))
+        )
+      )
+    );
+  }
+
+  @Test
+  void testRequestExecution() throws IOException {
+    Request request = Request.create(
+      Request.HttpMethod.GET,
+      "http://test-url",
+      Map.of("a", List.of("a-val")),
+      Request.Body.create("test-data"),
+      null
+    );
+
+    FolioExecutionContext context = mock(FolioExecutionContext.class);
+    when(context.getOkapiUrl()).thenReturn("http://okapi");
+    when(context.getOkapiHeaders()).thenReturn(Map.of("z", List.of("z-val")));
+    when(context.getAllHeaders())
+      .thenReturn(
+        Map.of(
+          "misc-1",
+          List.of("misc-1-val"),
+          "accept-language",
+          List.of("en-US,en;q=0.9"),
+          "misc-2",
+          List.of("misc-2-val")
+        )
+      );
+
+    Request.Options options = new Request.Options();
+
+    EnrichUrlAndHeadersClient client = new EnrichUrlAndHeadersClient(
+      context,
+      null
+    );
+
+    // best way to check for this without having to do a bunch of feign/okhttp logic
+    OkHttpClient mockedDelegate = mock(OkHttpClient.class);
+    ReflectionTestUtils.setField(client, "delegate", mockedDelegate);
+
+    when(mockedDelegate.execute(any(Request.class), eq(options)))
+      .thenReturn(Response.builder().request(request).status(299).build());
+
+    // ensure response is returned upon execution
+    assertThat(client.execute(request, options).status(), is(299));
+
+    // verify that the correct request was sent with the correct options
+    ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(
+      Request.class
+    );
+    verify(mockedDelegate, times(1))
+      .execute(requestCaptor.capture(), eq(options));
+
+    assertThat(
+      requestCaptor.getValue().httpMethod(),
+      is(Request.HttpMethod.GET)
+    );
+    assertThat(requestCaptor.getValue().url(), is("http://okapi/test-url"));
+    assertThat(
+      requestCaptor.getValue().headers(),
+      is(
+        allOf(
+          hasEntry("a", List.of("a-val")),
+          hasEntry("z", List.of("z-val")),
+          hasEntry("Accept-Language", List.of("en-US,en;q=0.9")),
+          is(aMapWithSize(3))
         )
       )
     );

--- a/folio-spring-base/src/test/java/org/folio/spring/client/EnrichUrlAndHeadersClientTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/client/EnrichUrlAndHeadersClientTest.java
@@ -1,0 +1,125 @@
+package org.folio.spring.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import feign.Request;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@UnitTest
+class EnrichUrlAndHeadersClientTest {
+
+  static List<Arguments> urlPreparationCases() {
+    return Arrays.asList(
+      arguments("http://test-url", null, "http://test-url"),
+      arguments("http://test-url", "http://okapi", "http://okapi/test-url"),
+      arguments("http://test-url", "http://okapi/", "http://okapi/test-url")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("urlPreparationCases")
+  void testUrlPreparation(String requestUrl, String okapiUrl, String expected) {
+    FolioExecutionContext context = mock(FolioExecutionContext.class);
+
+    when(context.getOkapiUrl()).thenReturn(okapiUrl);
+    assertThat(
+      EnrichUrlAndHeadersClient.prepareUrl(requestUrl, context),
+      is(expected)
+    );
+  }
+
+  @Test
+  void testHeaderPreparationWithNoLanguage() {
+    Request request = mock(Request.class);
+    when(request.headers())
+      .thenReturn(
+        Map.of(
+          "a",
+          List.of("a-val"),
+          "b",
+          List.of("b-val"),
+          "c",
+          List.of("c-val")
+        )
+      );
+
+    FolioExecutionContext context = mock(FolioExecutionContext.class);
+    when(context.getOkapiHeaders()).thenReturn(Map.of("z", List.of("z-val")));
+    when(context.getAllHeaders())
+      .thenReturn(
+        Map.of("misc-1", List.of("misc-1-val"), "misc-2", List.of("misc-2-val"))
+      );
+
+    assertThat(
+      EnrichUrlAndHeadersClient.prepareHeaders(request, context),
+      is(
+        allOf(
+          hasEntry("a", List.of("a-val")),
+          hasEntry("b", List.of("b-val")),
+          hasEntry("c", List.of("c-val")),
+          hasEntry("z", List.of("z-val")),
+          is(aMapWithSize(4))
+        )
+      )
+    );
+  }
+
+  @Test
+  void testHeaderPreparationWithLanguage() {
+    Request request = mock(Request.class);
+    when(request.headers())
+      .thenReturn(
+        Map.of(
+          "a",
+          List.of("a-val"),
+          "b",
+          List.of("b-val"),
+          "c",
+          List.of("c-val")
+        )
+      );
+
+    FolioExecutionContext context = mock(FolioExecutionContext.class);
+    when(context.getOkapiHeaders()).thenReturn(Map.of("z", List.of("z-val")));
+    when(context.getAllHeaders())
+      .thenReturn(
+        Map.of(
+          "misc-1",
+          List.of("misc-1-val"),
+          "accept-language",
+          List.of("en-US,en;q=0.9"),
+          "misc-2",
+          List.of("misc-2-val")
+        )
+      );
+
+    assertThat(
+      EnrichUrlAndHeadersClient.prepareHeaders(request, context),
+      is(
+        allOf(
+          hasEntry("a", List.of("a-val")),
+          hasEntry("b", List.of("b-val")),
+          hasEntry("c", List.of("c-val")),
+          hasEntry("z", List.of("z-val")),
+          hasEntry("Accept-Language", List.of("en-US,en;q=0.9")),
+          is(aMapWithSize(5))
+        )
+      )
+    );
+  }
+}

--- a/folio-spring-base/src/test/java/org/folio/spring/client/EnrichUrlAndHeadersClientTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/client/EnrichUrlAndHeadersClientTest.java
@@ -134,7 +134,7 @@ class EnrichUrlAndHeadersClientTest {
 
   @Test
   void testRequestExecution() throws IOException {
-    Request request = Request.create(
+    final Request request = Request.create(
       Request.HttpMethod.GET,
       "http://test-url",
       Map.of("a", List.of("a-val")),
@@ -142,7 +142,7 @@ class EnrichUrlAndHeadersClientTest {
       null
     );
 
-    FolioExecutionContext context = mock(FolioExecutionContext.class);
+    final FolioExecutionContext context = mock(FolioExecutionContext.class);
     when(context.getOkapiUrl()).thenReturn("http://okapi");
     when(context.getOkapiHeaders()).thenReturn(Map.of("z", List.of("z-val")));
     when(context.getAllHeaders())
@@ -157,15 +157,15 @@ class EnrichUrlAndHeadersClientTest {
         )
       );
 
-    Request.Options options = new Request.Options();
+    final Request.Options options = new Request.Options();
 
-    EnrichUrlAndHeadersClient client = new EnrichUrlAndHeadersClient(
+    final EnrichUrlAndHeadersClient client = new EnrichUrlAndHeadersClient(
       context,
       null
     );
 
     // best way to check for this without having to do a bunch of feign/okhttp logic
-    OkHttpClient mockedDelegate = mock(OkHttpClient.class);
+    final OkHttpClient mockedDelegate = mock(OkHttpClient.class);
     ReflectionTestUtils.setField(client, "delegate", mockedDelegate);
 
     when(mockedDelegate.execute(any(Request.class), eq(options)))

--- a/folio-spring-base/src/test/java/org/folio/spring/client/EnrichUrlAndHeadersClientTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/client/EnrichUrlAndHeadersClientTest.java
@@ -45,10 +45,7 @@ class EnrichUrlAndHeadersClientTest {
     FolioExecutionContext context = mock(FolioExecutionContext.class);
 
     when(context.getOkapiUrl()).thenReturn(okapiUrl);
-    assertThat(
-      EnrichUrlAndHeadersClient.prepareUrl(requestUrl, context),
-      is(expected)
-    );
+    assertThat(EnrichUrlAndHeadersClient.prepareUrl(requestUrl, context), is(expected));
   }
 
   @Test
@@ -65,10 +62,7 @@ class EnrichUrlAndHeadersClientTest {
 
     FolioExecutionContext context = mock(FolioExecutionContext.class);
     when(context.getOkapiHeaders()).thenReturn(Map.of("z", List.of("z-val")));
-    when(context.getAllHeaders())
-      .thenReturn(
-        Map.of("misc-1", List.of("misc-1-val"), "misc-2", List.of("misc-2-val"))
-      );
+    when(context.getAllHeaders()).thenReturn(Map.of("misc-1", List.of("misc-1-val"), "misc-2", List.of("misc-2-val")));
 
     assertThat(
       EnrichUrlAndHeadersClient.prepareHeaders(request, context),
@@ -146,10 +140,7 @@ class EnrichUrlAndHeadersClientTest {
 
     final Request.Options options = new Request.Options();
 
-    final EnrichUrlAndHeadersClient client = new EnrichUrlAndHeadersClient(
-      context,
-      null
-    );
+    final EnrichUrlAndHeadersClient client = new EnrichUrlAndHeadersClient(context, null);
 
     // best way to check for this without having to do a bunch of feign/okhttp logic
     final OkHttpClient mockedDelegate = mock(OkHttpClient.class);
@@ -162,16 +153,10 @@ class EnrichUrlAndHeadersClientTest {
     assertThat(client.execute(request, options).status(), is(299));
 
     // verify that the correct request was sent with the correct options
-    ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(
-      Request.class
-    );
-    verify(mockedDelegate, times(1))
-      .execute(requestCaptor.capture(), eq(options));
+    ArgumentCaptor<Request> requestCaptor = ArgumentCaptor.forClass(Request.class);
+    verify(mockedDelegate, times(1)).execute(requestCaptor.capture(), eq(options));
 
-    assertThat(
-      requestCaptor.getValue().httpMethod(),
-      is(Request.HttpMethod.GET)
-    );
+    assertThat(requestCaptor.getValue().httpMethod(), is(Request.HttpMethod.GET));
     assertThat(requestCaptor.getValue().url(), is("http://okapi/test-url"));
     assertThat(
       requestCaptor.getValue().headers(),


### PR DESCRIPTION
# [Jira FOLSPRINGB-139](https://issues.folio.org/browse/FOLSPRINGB-139)

## Purpose
Currently, we pass any `x-okapi` headers to other modules via feign clients, allowing sharing of token, user, and other request metadata.  We should also do this with the `Accept-Language` header, to ensure that any requests made also include this information, enabling downstream APIs to return locale-aware results.

## Approach
This alters `EnrichUrlAndHeadersClient` to also check for and pass the `Accept-Language` header.  For ease of testing, the class has also been slightly refactored to extract some logic into static, easily-testable classes.

## Notes
I see the code smell, and I have no clue how to address it — it seems to be a false positive that is not applicable in this case.
