### PR TITLE
FOLSPRINGB-144: Add support for Cql filtering by (un)defined attribute value

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## 8.1.0-SNAPSHOT
-* [FOLSPRINGB-144](https://issues.folio.org/browse/FOLSPRINGB-144) Add support for filtering by non-specified attribute value indicated as 'null' in Cql query
+* [FOLSPRINGB-144](https://issues.folio.org/browse/FOLSPRINGB-144) Add support for filtering by undefined field value
 
 ## 8.0.0 2024-01-19
 * [FOLSPRINGB-128](https://issues.folio.org/browse/FOLSPRINGB-128) System User POC

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 8.1.0-SNAPSHOT
+* [FOLSPRINGB-144](https://issues.folio.org/browse/FOLSPRINGB-144) Add support for filtering by non-specified attribute value indicated as 'null' in Cql query
+
 ## 8.0.0 2024-01-19
 * [FOLSPRINGB-128](https://issues.folio.org/browse/FOLSPRINGB-128) System User POC
 * [FOLSPRINGB-139](https://issues.folio.org/browse/FOLSPRINGB-139) Pass Accept-Language header in Feign clients

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
@@ -301,7 +301,7 @@ public class Cql2JpaCriteria<E> {
     var comparator = node.getRelation().getBase().toLowerCase();
     var term = node.getTerm();
 
-    if (equalsAny(comparator, "=", "==") && (StringUtils.isBlank(term) || term.equals("''"))) {
+    if (equalsAny(comparator, "=", "==") && StringUtils.isEmpty(term)) {
       return definedOrDefinedAndEmptyQuery(field, comparator, cb);
     }
 

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
@@ -99,7 +99,7 @@ class JpaCqlRepositoryIT {
     assertThat(personRepository.countDeletedFalse("(cql.allRecords=1)sortby age/sort.ascending"))
       .isEqualTo(5);
     assertThat(personRepository.count("(cql.allRecords=1)sortby age/sort.ascending"))
-      .isEqualTo(8);
+      .isEqualTo(9);
   }
 
   @Sql({

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
@@ -106,13 +106,17 @@ class JpaCqlRepositoryIT {
   })
   @ParameterizedTest
   @CsvSource({
-    "city=null, 1, ,John2",
-    "city.id=null, 1, ,John2",
-    "city.name=null, 1, ,John2",
-    "identifier=\"\", 7, John2, Jane;John",
-    "name<>\"\", 8, ,Jane;John;John2",
-    "name<>null, 8, ,Jane;John;John2",
-    "city<>null, 7, John2, Jane;John",
+    "city=\"\", 7, John2, Jane;John",
+    "cql.allRecords=1 NOT city=\"\", 1, John, John2",
+    "city<>\"\", 1, John, John2",
+    "city.id=\"\", 7, John2, Jane;John",
+    "cql.allRecords=1 NOT city.id=\"\", 1, John, John2",
+    "city.id<>\"\", 1, John, John2",
+    "city.name=\"\", 7, John2, Jane;John",
+    "city.name<>\"\", 1, , John2",
+    "identifier=\"\", 1, , John2",
+    "name=\"\", 8, ,Jane;John;John2",
+    "name<>\"peter\", 8, ,Jane;John;John2"
   })
   void testSelectAllRecordsByNonSpecifiedField(String query, int expectedSize, String excludedName,
                                                String includedNames) {

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
@@ -107,19 +107,22 @@ class JpaCqlRepositoryIT {
   })
   @ParameterizedTest
   @CsvSource({
-    "city=\"\", 7, John2, Jane;John",
-    "city='', 7, John2, Jane;John",
+    "city=\"\", 8, John2, Jane;John",
+    "city='', 8, John2, Jane;John",
     "cql.allRecords=1 NOT city=\"\", 1, Jane;John, John2",
     "age>30 NOT city=\"\", 1, Jane;John, John2",
     "name=John NOT city=\"\", 0, John2,",
-    "city.id=\"\", 7, John2, Jane;John",
+    "city.id=\"\", 8, John2, Jane;John",
     "cql.allRecords=1 NOT city.id=\"\", 1, Jane;John, John2",
     "age=40 NOT city.id='', 1, Jane;John, John2",
-    "city.name=\"\", 7, John2, Jane;John",
+    "city.name=\"\", 8, John2, Jane;John",
     "identifier=\"\" NOT city.id=\"\", 1, Jane;John, John2",
-    "name=\"\", 8, , Jane;John;John2",
-    "name='', 8, , Jane;John;John2",
-    "name<>\"peter\", 8, , Jane;John;John2"
+    "name=\"\", 9, , Jane;John;John2",
+    "city.name==\"\", 1, Jane;John;John2, Jane2",
+    "age<45 NOT city.name==\"\", 8, Jane2, Jane;John;John2",
+    "city.name=\"\" NOT city.name==\"\", 7, Jane2;John2, Jane;John",
+    "name='', 9, , Jane;John;John2",
+    "name<>\"peter\", 9, , Jane;John;John2"
   })
   void testSelectAllRecordsByNonSpecifiedField(String query, int expectedSize, String excludedNames,
                                                String includedNames) {

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
@@ -108,20 +108,19 @@ class JpaCqlRepositoryIT {
   @ParameterizedTest
   @CsvSource({
     "city=\"\", 8, John2, Jane;John",
-    "city='', 8, John2, Jane;John",
     "cql.allRecords=1 NOT city=\"\", 1, Jane;John, John2",
     "age>30 NOT city=\"\", 1, Jane;John, John2",
     "name=John NOT city=\"\", 0, John2,",
     "city.id=\"\", 8, John2, Jane;John",
     "cql.allRecords=1 NOT city.id=\"\", 1, Jane;John, John2",
-    "age=40 NOT city.id='', 1, Jane;John, John2",
+    "age=40 NOT city.id=\"\", 1, Jane;John, John2",
     "city.name=\"\", 8, John2, Jane;John",
     "identifier=\"\" NOT city.id=\"\", 1, Jane;John, John2",
     "name=\"\", 9, , Jane;John;John2",
     "city.name==\"\", 1, Jane;John;John2, Jane2",
     "age<45 NOT city.name==\"\", 8, Jane2, Jane;John;John2",
     "city.name=\"\" NOT city.name==\"\", 7, Jane2;John2, Jane;John",
-    "name='', 9, , Jane;John;John2",
+    "name=\"\", 9, , Jane;John;John2",
     "name<>\"peter\", 9, , Jane;John;John2"
   })
   void testSelectAllRecordsByNonSpecifiedField(String query, int expectedSize, String excludedNames,

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-person-test-data.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-person-test-data.sql
@@ -1,5 +1,8 @@
+insert into city(id, name) values (3, '');
+
 insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (104, 'Jane', 26, 1, '2001-01-03', '2001-01-03', false, '2021-12-25T06:31:31+05:00');
 insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (105, 'John', 30, 1, '2001-01-02', '2001-01-02', false, '2021-12-25T06:31:31+05:00');
 insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (106, 'Jane', 32, 1, '2001-01-03', '2001-01-03', true, '2021-12-25T06:31:31+05:00');
 insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (107, 'John', 33, 1, '2001-01-02', '2001-01-02', true, '2021-12-25T06:31:31+05:00');
 insert into person(id, name, age, identifier, city_id, date_born, local_date, deleted, created_date) values (108, 'John2', 40, '29fce73c-06c6-4680-ba14-de1560d68efd', null, '2001-01-02', '2001-01-02', true, '2021-12-31T06:31:31+05:00');
+insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (109, 'Jane2', 45, 3, '2001-01-02', '2001-01-02', true, '2021-12-31T06:31:31+05:00');

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-person-test-data.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-person-test-data.sql
@@ -2,3 +2,4 @@ insert into person(id, name, age, city_id, date_born, local_date, deleted, creat
 insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (105, 'John', 30, 1, '2001-01-02', '2001-01-02', false, '2021-12-25T06:31:31+05:00');
 insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (106, 'Jane', 32, 1, '2001-01-03', '2001-01-03', true, '2021-12-25T06:31:31+05:00');
 insert into person(id, name, age, city_id, date_born, local_date, deleted, created_date) values (107, 'John', 33, 1, '2001-01-02', '2001-01-02', true, '2021-12-25T06:31:31+05:00');
+insert into person(id, name, age, identifier, city_id, date_born, local_date, deleted, created_date) values (108, 'John2', 40, '29fce73c-06c6-4680-ba14-de1560d68efd', null, '2001-01-02', '2001-01-02', true, '2021-12-31T06:31:31+05:00');


### PR DESCRIPTION
## Purpose
_Support filtering by undefined SQL DB Table attribute value._

## Approach
_Specifically handle the case where attribute is defined with any value or undefined at all_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
- [x] Update News.md

## Learning
[FOLSPRINGS-144](https://folio-org.atlassian.net/browse/FOLSPRINGS-144)
