### PR TITLE
FOLSPRINGS-153: commons-compress 1.26.1, unpin testcontainers, wiremock 3.4.2

### DIFF
--- a/folio-spring-testing/pom.xml
+++ b/folio-spring-testing/pom.xml
@@ -9,11 +9,6 @@
 
   <artifactId>folio-spring-testing</artifactId>
 
-  <properties>
-    <testcontainers.version>1.19.6</testcontainers.version>
-    <wiremock.version>3.0.1</wiremock.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -67,31 +62,26 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>${testcontainers.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>${testcontainers.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
-      <version>${testcontainers.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>${testcontainers.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>minio</artifactId>
-      <version>${testcontainers.version}</version>
     </dependency>
 
     <dependency>
@@ -100,12 +90,22 @@
     </dependency>
 
     <dependency>
-      <groupId>com.github.tomakehurst</groupId>
+      <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
     </dependency>
 
-    <!-- https://mvnrepository.com/artifact/org.junit.platform/junit-platform-launcher -->
+    <!-- Bump wiremock's commons-compress 1.24.0 that has vulnerabilities:
+         https://nvd.nist.gov/vuln/detail/CVE-2024-25710
+         https://nvd.nist.gov/vuln/detail/CVE-2024-26308
+         https://github.com/testcontainers/testcontainers-java/issues/8169
+    -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>${commons-compress.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>

--- a/folio-spring-testing/pom.xml
+++ b/folio-spring-testing/pom.xml
@@ -84,6 +84,17 @@
       <artifactId>minio</artifactId>
     </dependency>
 
+    <!-- Bump testcontainer's commons-compress 1.24.0 that has vulnerabilities:
+         https://nvd.nist.gov/vuln/detail/CVE-2024-25710
+         https://nvd.nist.gov/vuln/detail/CVE-2024-26308
+         https://github.com/testcontainers/testcontainers-java/issues/8169
+    -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>${commons-compress.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.jeasy</groupId>
       <artifactId>easy-random-core</artifactId>
@@ -93,17 +104,6 @@
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
       <version>${wiremock.version}</version>
-    </dependency>
-
-    <!-- Bump wiremock's commons-compress 1.24.0 that has vulnerabilities:
-         https://nvd.nist.gov/vuln/detail/CVE-2024-25710
-         https://nvd.nist.gov/vuln/detail/CVE-2024-26308
-         https://github.com/testcontainers/testcontainers-java/issues/8169
-    -->
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-compress</artifactId>
-      <version>${commons-compress.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,8 @@
     <!-- Test dependencies versions -->
     <easy-random.version>5.0.0</easy-random.version>
     <mockito-inline.version>5.2.0</mockito-inline.version>
+    <wiremock.version>3.4.2</wiremock.version>
+    <commons-compress.version>1.26.1</commons-compress.version>
 
     <!-- Plugins versions -->
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>


### PR DESCRIPTION
Upgrade commons-compress from 1.24.0 to 1.26.1 fixing security vulnerabilities:

* https://nvd.nist.gov/vuln/detail/CVE-2024-25710 - Infinite loop
* https://nvd.nist.gov/vuln/detail/CVE-2024-26308 - Allocation of Resources Without Limits or Throttling

In addition unpin testcontainers version because the Spring Boot provided version overwrites the testcontainers provided version:

```
mvn dependency:tree -Dincludes=:commons-compress -Dverbose

[INFO] org.folio:folio-spring-testing:jar:8.2.0-SNAPSHOT
[INFO] \- org.testcontainers:testcontainers:jar:1.19.6:compile
[INFO]    \- org.apache.commons:commons-compress:jar:1.24.0:compile

[INFO] org.folio:folio-spring-cql:jar:8.2.0-SNAPSHOT
[INFO] \- org.folio:folio-spring-testing:jar:8.2.0-SNAPSHOT:test
[INFO]    \- org.testcontainers:testcontainers:jar:1.19.5:test (version managed from 1.19.6)
[INFO]       \- org.apache.commons:commons-compress:jar:1.24.0:test
```

Bump wiremock from unsupported 3.0.1 to 3.4.2.