### PR TITLE
FOLSPRINGS-154 Exclude edge-api-utils from system-user submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+    groups:
+      dev-deps:
+        dependency-type: "development"
+      prod-deps:
+        dependency-type: "production"

--- a/folio-spring-system-user/pom.xml
+++ b/folio-spring-system-user/pom.xml
@@ -49,6 +49,11 @@
       </exclusions>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-http</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -65,25 +70,6 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-codec-http</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.folio</groupId>
-      <artifactId>edge-api-utils</artifactId>
-      <version>${edge-api-utils-version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>log4j-to-slf4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 

--- a/folio-spring-system-user/src/main/java/org/folio/spring/exception/SystemUserAuthorizationException.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/exception/SystemUserAuthorizationException.java
@@ -1,0 +1,11 @@
+package org.folio.spring.exception;
+
+public class SystemUserAuthorizationException extends RuntimeException {
+  public SystemUserAuthorizationException(String message) {
+    super(message);
+  }
+
+  public SystemUserAuthorizationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
     <feign-okhttp.version>13.1</feign-okhttp.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
     <cql2pgjson.version>35.1.1</cql2pgjson.version>
-    <edge-api-utils-version>1.3.0</edge-api-utils-version>
     <rhino.version>1.7.14</rhino.version>
     <icu4j.version>74.2</icu4j.version>
 


### PR DESCRIPTION
## Purpose
edge-api-utils is adding unnecessary dependencies to the system-user submodule. This can lead to increased vulnerabilities in modules that use it.

## Approach
Exclude edge-api-utils from system-user submodule
