### PR TITLE
FOLSPRINGS-156: Spring Boot 3.2.6, bcprov-jdk18on 1.78 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.4</version> <!-- also change spring-boot.version -->
+    <version>3.2.6</version> <!-- also change spring-boot.version -->
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -30,8 +30,10 @@
 
   <properties>
     <java.version>17</java.version>
-    <spring-boot.version>3.2.4</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
+    <spring-boot.version>3.2.6</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
     <spring-cloud-starter-openfeign.version>4.1.1</spring-cloud-starter-openfeign.version>
+    <!-- remove spring-security-rsa dependency when spring-cloud-starter-openfeign ships with spring-security-rsa >= 1.1.3 -->
+    <spring-security-rsa.version>1.1.3</spring-security-rsa.version>
     <maven-compat.version>3.9.6</maven-compat.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
     <swagger-annotations.version>2.2.21</swagger-annotations.version>
@@ -79,6 +81,18 @@
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-starter-openfeign</artifactId>
         <version>${spring-cloud-starter-openfeign.version}</version>
+      </dependency>
+
+      <!-- remove this explicit spring-security-rsa dependency when spring-cloud-starter-openfeign ships with spring-security-rsa >= 1.1.3
+           Needed to bump org.bouncycastle:bcprov-jdk18on from 1.74 to 1.78 to fix
+           https://nvd.nist.gov/vuln/detail/CVE-2024-30172
+           https://nvd.nist.gov/vuln/detail/CVE-2024-30171
+           https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6277381
+      -->
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-rsa</artifactId>
+        <version>1.1.3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLSPRINGS-156

Upgrade Spring Boot from 3.2.4 to 3.2.6.

Upgrade spring-security-rsa from 1.1.2 to 1.1.3.

The Spring Boot upgrade indirectly upgrades spring-web from 6.1.3 to 6.1.8 fixing UriComponentsBuilder Open Redirect:

https://spring.io/security/cve-2024-22259
https://spring.io/security/cve-2024-22262

The Spring Boot upgrade indirectly upgrades netty-codec-http from 4.1.107.Final to 4.1.110.Final fixing form POST OOM:

https://github.com/netty/netty/security/advisories/GHSA-5jpm-x58v-624v = CVE-2024-29025

The spring-security-rsa upgrade indirectly upgrades bcprov-jdk18on from 1.74 to 1.78 fixing multiple vulnerabilities:

* https://www.cve.org/CVERecord?id=CVE-2024-30172 Ed25519 Infinitive Loop
* https://www.cve.org/CVERecord?id=CVE-2024-30171 RSA side-channel attack
* https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6277381 PKCS#1 1.5 and OAEP side-channel attack
* https://www.cve.org/CVERecord?id=CVE-2024-29857 ECCurve excessive CPU consumption

## Purpose
Fix security vulnerabilities.

## Approach
Upgrade patch versions of two dependencies:

* Upgrade Spring Boot from 3.2.4 to 3.2.6.
* Upgrade spring-security-rsa from 1.1.2 to 1.1.3.
