### PR TITLE
FOLSPRINGS-158: spring-security-rsa 1.1.3 fixing bcprov-jdk18on TLS

### DIFF
--- a/folio-spring-base/pom.xml
+++ b/folio-spring-base/pom.xml
@@ -61,6 +61,19 @@
       <artifactId>spring-cloud-starter-openfeign</artifactId>
     </dependency>
 
+    <!-- Upgrade spring-security-rsa from 1.1.2 to 1.1.3.
+         Remove this explicit spring-security-rsa dependency when spring-cloud-starter-openfeign ships with spring-security-rsa >= 1.1.3.
+         Needed to bump org.bouncycastle:bcprov-jdk18on from 1.74 to 1.78 to fix
+         https://nvd.nist.gov/vuln/detail/CVE-2024-30172
+         https://nvd.nist.gov/vuln/detail/CVE-2024-30171
+         https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6277381
+    -->
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-rsa</artifactId>
+      <version>1.1.3</version>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
   <properties>
     <java.version>17</java.version>
     <spring-boot.version>3.3.0</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
+    <!-- Remove the spring-security-rsa dependency in folio-spring-base when spring-cloud-starter-openfeign ships with spring-security-rsa >= 1.1.3. -->
     <spring-cloud-starter-openfeign.version>4.1.1</spring-cloud-starter-openfeign.version>
     <maven-compat.version>3.9.7</maven-compat.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>


### PR DESCRIPTION
Latest spring-cloud-starter-openfeign:4.1.1 comes with spring-security-rsa:jar:1.1.2 and bcprov-jdk18on:jar:1.77.

bcprov-jdk18on:jar:1.77 has multiple vulnerabilities:

* https://www.cve.org/CVERecord?id=CVE-2024-30172  Ed25519 Infinitive Loop
* https://www.cve.org/CVERecord?id=CVE-2024-30171  RSA side-channel attack
* https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6277381  PKCS#1 1.5 and OAEP side-channel attack
* https://www.cve.org/CVERecord?id=CVE-2024-29857  ECCurve excessive CPU consumption

The bcprov-jdk18on vulnerabilities affect TLS:

* Both Ed25519 and RSA/*-RSA are used in TLSv1.2 and TLSv1.3: https://en.wikipedia.org/wiki/Transport_Layer_Security#Key_exchange_or_key_agreement
* ECCurve is a commonly used public key algorithm for certificates in TLSv1.2 and TLSv1.3. http://Letsencrypt.org  certbot uses it by default since version 2.0.0.

Upgrading spring-security-rsa from 1.1.2 to 1.1.3 indirectly upgrades bcprov-jdk18on from 1.77 to 1.78 fixing these vulnerabilities.

Dependencies before fix:

`mvn dependency:tree -Dverbose -Dincludes=:bcprov-jdk18on`
```
[INFO] org.folio:folio-spring-base:jar:8.2.0-SNAPSHOT
[INFO] \- org.springframework.cloud:spring-cloud-starter-openfeign:jar:4.1.1:compile
[INFO]    \- org.springframework.cloud:spring-cloud-starter:jar:4.1.2:compile
[INFO]       \- org.springframework.security:spring-security-rsa:jar:1.1.2:compile
[INFO]          \- org.bouncycastle:bcprov-jdk18on:jar:1.77:compile
```