### PR TITLE
[FOLSPRINGS-157] Add missing property to LoginResponse in folio-spring-system-user

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 ## 8.2.0 In progress
 ### Testing submodule
 * [FOLSPRINGB-152](https://issues.folio.org/browse/FOLSPRINGB-152) Implement TESTCONTAINERS_POSTGRES_IMAGE
+### folio-spring-system-user
+* [FOLSPRINGS-157](https://issues.folio.org/browse/FOLSPRINGS-157) Add missing property to authn client, to allow for `fail-on-unknown-properties` in consuming modules
 
 ### i18n submodule
 * [FOLSPRINGB-160](https://issues.folio.org/browse/FOLSPRINGB-160) Make translation service accept multiple keys

--- a/folio-spring-system-user/src/main/java/org/folio/spring/client/AuthnClient.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/client/AuthnClient.java
@@ -27,6 +27,6 @@ public interface AuthnClient {
   record UserCredentials(String username, String password) {
   }
 
-  record LoginResponse(String accessTokenExpiration) {
+  record LoginResponse(String accessTokenExpiration, String refreshTokenExpiration) {
   }
 }

--- a/folio-spring-system-user/src/test/java/org/folio/spring/systemuser/SystemUserServiceTest.java
+++ b/folio-spring-system-user/src/test/java/org/folio/spring/systemuser/SystemUserServiceTest.java
@@ -58,13 +58,15 @@ class SystemUserServiceTest {
   public static final String OKAPI_URL = "http://okapi";
   private static final String TENANT_ID = "test";
   private static final Instant TOKEN_EXPIRATION = Instant.now().plus(1, ChronoUnit.DAYS);
+  private static final Instant REFRESH_TOKEN_EXPIRATION = Instant.now().plus(7, ChronoUnit.DAYS);
   private static final Instant CUSTOM_TOKEN_EXPIRATION = TOKEN_EXPIRATION.minus(12, ChronoUnit.HOURS)
     .truncatedTo(ChronoUnit.MINUTES);
   private static final String MOCK_TOKEN = "test_token";
   private static final String CANNOT_RETRIEVE_OKAPI_TOKEN_FOR_TENANT_TENANT_ID
     = "Cannot retrieve okapi token for tenant: tenantId";
   private final ResponseEntity<AuthnClient.LoginResponse> expectedResponse =
-    Mockito.spy(ResponseEntity.of(Optional.of(new AuthnClient.LoginResponse(TOKEN_EXPIRATION.toString()))));
+    Mockito.spy(ResponseEntity.of(Optional.of(
+      new AuthnClient.LoginResponse(TOKEN_EXPIRATION.toString(), REFRESH_TOKEN_EXPIRATION.toString()))));
   @Mock
   private AuthnClient authnClient;
   @Mock
@@ -378,7 +380,7 @@ class SystemUserServiceTest {
   private ResponseEntity<AuthnClient.LoginResponse> buildClientResponse(String token) {
     return ResponseEntity.ok()
       .header(XOkapiHeaders.TOKEN, token)
-      .body(new AuthnClient.LoginResponse(TOKEN_EXPIRATION.toString()));
+      .body(new AuthnClient.LoginResponse(TOKEN_EXPIRATION.toString(), REFRESH_TOKEN_EXPIRATION.toString()));
   }
 
   private Response create404Response() {

--- a/folio-spring-system-user/src/test/java/org/folio/spring/utils/TokenUtilsTest.java
+++ b/folio-spring-system-user/src/test/java/org/folio/spring/utils/TokenUtilsTest.java
@@ -22,7 +22,7 @@ class TokenUtilsTest {
   void parseUserTokenFromCookies_positive() {
     var tokenTtlMinutes = 10;
     var accessExp = Instant.now().plus(tokenTtlMinutes, ChronoUnit.MINUTES).truncatedTo(ChronoUnit.MINUTES);
-    var authResponse = new AuthnClient.LoginResponse(accessExp.toString());
+    var authResponse = new AuthnClient.LoginResponse(accessExp.toString(), null);
     var accessToken = "acc";
     var cookies = List.of(new DefaultCookie(FOLIO_ACCESS_TOKEN, accessToken).toString());
     var expected = UserToken.builder()
@@ -40,7 +40,7 @@ class TokenUtilsTest {
   @ParameterizedTest
   @CsvSource({",1970-01-01T00:00:00Z"})
   void parseUserTokenFromCookies_negative_invalidExpiration(String accessExp, String refreshExp) {
-    var authResponse = new AuthnClient.LoginResponse(accessExp);
+    var authResponse = new AuthnClient.LoginResponse(accessExp, null);
     var accessToken = "acc";
     var refreshToken = "ref";
     var cookies = List.of(new DefaultCookie(FOLIO_ACCESS_TOKEN, accessToken).toString());
@@ -54,7 +54,7 @@ class TokenUtilsTest {
   @ParameterizedTest
   @CsvSource({"folioRefreshToken,folioAccessToken"})
   void parseUserTokenFromCookies_negative_missingCookie(String cookieName, String missingCookie) {
-    var authResponse = new AuthnClient.LoginResponse("");
+    var authResponse = new AuthnClient.LoginResponse("", null);
     var token = "token";
     var cookies = List.of(new DefaultCookie(cookieName, token).toString());
 


### PR DESCRIPTION
The `AuthnClient` which communicates with `mod-login` via [this endpoint](https://s3.amazonaws.com/foliodocs/api/mod-login/r/login.html#authn_login_with_expiry_post), however, the `folio-spring-system-user` library does not anticipate the full response, causing errors in certain modules where `fail-on-unknown-properties` is set to true (currently, only one module uses this, and that module had to disable that flag to use the library).

See https://folio-project.slack.com/archives/C01HUKJCMC7/p1716305138170359?thread_ts=1716301442.701229&cid=C01HUKJCMC7 for more details.