### PR TITLE
FOLSPRINGS-161: Spring Boot 3.4

### DIFF
--- a/folio-spring-base/pom.xml
+++ b/folio-spring-base/pom.xml
@@ -33,6 +33,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/folio-spring-base/pom.xml
+++ b/folio-spring-base/pom.xml
@@ -14,6 +14,9 @@
 
   <properties>
     <tenant.yaml.file>${project.basedir}/src/main/resources/swagger.api/tenant.yaml</tenant.yaml.file>
+    <sonar.exclusions>
+      src/main/java/org/folio/**/FolioLiquibaseConfiguration.java
+    </sonar.exclusions>
   </properties>
 
   <dependencies>

--- a/folio-spring-base/src/main/java/org/folio/spring/liquibase/FolioLiquibaseConfiguration.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/liquibase/FolioLiquibaseConfiguration.java
@@ -12,6 +12,8 @@ import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfigurat
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(prefix = "spring.liquibase", name = "enabled", matchIfMissing = true)
@@ -33,7 +35,9 @@ public class FolioLiquibaseConfiguration {
     liquibase.setDataSource(dataSource);
     liquibase.setChangeLog(this.properties.getChangeLog());
     liquibase.setClearCheckSums(this.properties.isClearChecksums());
-    liquibase.setContexts(this.properties.getContexts());
+    if (!CollectionUtils.isEmpty(properties.getContexts())) {
+      liquibase.setContexts(StringUtils.collectionToCommaDelimitedString(properties.getContexts()));
+    }
     liquibase.setDefaultSchema(this.properties.getDefaultSchema());
     liquibase.setLiquibaseSchema(this.properties.getLiquibaseSchema());
     liquibase.setLiquibaseTablespace(this.properties.getLiquibaseTablespace());
@@ -41,7 +45,9 @@ public class FolioLiquibaseConfiguration {
     liquibase.setDatabaseChangeLogLockTable(this.properties.getDatabaseChangeLogLockTable());
     liquibase.setDropFirst(this.properties.isDropFirst());
     liquibase.setShouldRun(this.properties.isEnabled());
-    liquibase.setLabelFilter(this.properties.getLabelFilter());
+    if (!CollectionUtils.isEmpty(properties.getLabelFilter())) {
+      liquibase.setLabelFilter(StringUtils.collectionToCommaDelimitedString(properties.getLabelFilter()));
+    }
     liquibase.setChangeLogParameters(this.properties.getParameters());
     liquibase.setRollbackFile(this.properties.getRollbackFile());
     liquibase.setTestRollbackOnUpdate(this.properties.isTestRollbackOnUpdate());

--- a/folio-spring-cql/pom.xml
+++ b/folio-spring-cql/pom.xml
@@ -17,6 +17,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.5</version> <!-- also change spring-boot.version -->
+    <version>3.4.0</version> <!-- also change spring-boot.version -->
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -30,8 +30,8 @@
 
   <properties>
     <java.version>17</java.version>
-    <spring-boot.version>3.3.5</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
-    <spring-cloud-starter-openfeign.version>4.1.4</spring-cloud-starter-openfeign.version>
+    <spring-boot.version>3.4.0</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
+    <spring-cloud-starter-openfeign.version>4.2.0</spring-cloud-starter-openfeign.version>
     <maven-compat.version>3.9.9</maven-compat.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
     <swagger-annotations.version>2.2.26</swagger-annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.2</version> <!-- also change spring-boot.version -->
+    <version>3.4.0-M1</version> <!-- also change spring-boot.version -->
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -30,8 +30,8 @@
 
   <properties>
     <java.version>17</java.version>
-    <spring-boot.version>3.3.2</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
-    <spring-cloud-starter-openfeign.version>4.1.3</spring-cloud-starter-openfeign.version>
+    <spring-boot.version>3.4.0-M1</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
+    <spring-cloud-starter-openfeign.version>4.2.0-SNAPSHOT</spring-cloud-starter-openfeign.version>
     <maven-compat.version>3.9.8</maven-compat.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>
     <swagger-annotations.version>2.2.22</swagger-annotations.version>
@@ -357,6 +357,16 @@
       <id>folio-nexus</id>
       <name>FOLIO Maven Repository</name>
       <url>https://repository.folio.org/repository/maven-folio</url>
+    </repository>
+    <repository>
+      <id>repo.spring.io-milestone</id>
+      <name>Spring Milestone Repository</name>
+      <url>https://repo.spring.io/milestone</url>
+    </repository>
+    <repository>
+      <id>repo.spring.io-snapshot</id>
+      <name>Spring Snapshot Repository</name>
+      <url>https://repo.spring.io/snapshot</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
## Purpose
Upgrade from Spring Boot 3.3 to Spring Boot 3.4 for Sunflower
US: [FOLSPRINGS-161](https://folio-org.atlassian.net/browse/FOLSPRINGS-161), [FOLSPRINGS-177](https://folio-org.atlassian.net/browse/FOLSPRINGS-177)

## Approach
* upgrade to `spring-boot v3.4.0` and `spring-cloud-starter-openfeign v4.2.0`
* exclude `spring-boot-starter-logging` from `spring-boot-starter-data-jpa` to avoid different slf4j2 implementations
* adjust `FolioLiquibaseConfiguration` according to https://github.com/spring-projects/spring-boot/commit/fae3cd1ca55575c01df324de04391cddf7fb9cd6#diff-3690614f74b4c856a949f9746fd77a870c9d32fc90ade726e515780a17c65a2aR109