### PR TITLE
Fixed PostProcessorChecker Warnings

### DIFF
--- a/folio-spring-base/src/main/java/org/folio/spring/config/FolioSpringConfiguration.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/config/FolioSpringConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 @Configuration
 @ComponentScan({"org.folio.spring.controller", "org.folio.spring.config",
@@ -49,8 +50,8 @@ public class FolioSpringConfiguration {
 
   @Bean
   @Qualifier("dataSourceSchemaAdvisorBeanPostProcessor")
-  public BeanPostProcessor dataSourceSchemaAdvisorBeanPostProcessor(
-    @Autowired FolioExecutionContext folioExecutionContext) {
+  public static BeanPostProcessor dataSourceSchemaAdvisorBeanPostProcessor(
+    @Autowired @Lazy FolioExecutionContext folioExecutionContext) {
     return new DataSourceSchemaAdvisorBeanPostProcessor(folioExecutionContext);
   }
 


### PR DESCRIPTION
## Purpose
Optimize injection in the `DataSourceSchemaAdvisorBeanPostProcessor`

Remove warnings
```
WARN  PostProcessorChecker Bean 'org.folio.spring.config.FolioSpringConfiguration' of type [org.folio.spring.config.FolioSpringConfiguration$$SpringCGLIB$$0] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). The currently created BeanPostProcessor [dataSourceSchemaAdvisorBeanPostProcessor] is declared through a non-static factory method on that class; consider declaring it as static instead.
WARN  PostProcessorChecker Bean 'folioExecutionContext' of type [org.springframework.aop.scope.ScopedProxyFactoryBean] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). Is this bean getting eagerly injected into a currently created BeanPostProcessor [dataSourceSchemaAdvisorBeanPostProcessor]? Check the corresponding BeanPostProcessor declaration and its dependencies.
WARN  PostProcessorChecker Bean 'folioExecutionContext' of type [jdk.proxy2.$Proxy133] is not eligible for getting processed by all BeanPostProcessors (for example: not eligible for auto-proxying). Is this bean getting eagerly injected into a currently created BeanPostProcessor [dataSourceSchemaAdvisorBeanPostProcessor]? Check the corresponding BeanPostProcessor declaration and its dependencies.
```