### PR TITLE
fix(kafka-container): Fix creating compatible Kafka Test Container

### DIFF
--- a/folio-spring-testing/src/main/java/org/folio/spring/testing/extension/impl/KafkaContainerExtension.java
+++ b/folio-spring-testing/src/main/java/org/folio/spring/testing/extension/impl/KafkaContainerExtension.java
@@ -16,7 +16,8 @@ import org.testcontainers.utility.DockerImageName;
 public class KafkaContainerExtension implements BeforeAllCallback, AfterAllCallback {
 
   private static final String SPRING_PROPERTY_NAME = "spring.kafka.bootstrap-servers";
-  private static final DockerImageName KAFKA_IMAGE = parse("apache/kafka-native:3.8.0");
+  private static final DockerImageName KAFKA_IMAGE =
+    parse("apache/kafka-native:3.8.0").asCompatibleSubstituteFor("apache/kafka");
   private static final KafkaContainer CONTAINER = new KafkaContainer(KAFKA_IMAGE)
     .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
 


### PR DESCRIPTION
## Purpose
_Testcontainer fails to verify ```apache/kafka-native:3.8.0``` and create ```KafkaContainer```_

## Approach
Indicate the ```apache/kafka-native:3.8.0``` image as compatible to ```apache/kafka```

#### TODOS and Open Questions
- [ ] Update NEWS.md.
- [ ] _Use GitHub checklists. When solved, check the box and explain the answer._

## Learning
https://folio-org.atlassian.net/browse/FOLSPRINGS-165
