### PR TITLE
Revert "FOLSPRINGS-165: kafka.KafkaContainer, apache/kafka-native:3.8.0"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,7 @@
 ## 8.2.0 In progress
 * [FOLSPRINGS-164](https://folio-org.atlassian.net/browse/FOLSPRINGS-164) Add "Update NEWS.md" to PULL\_REQUEST\_TEMPLATE.md
 ### Testing submodule
-* [FOLSPRINGB-152](https://issues.folio.org/browse/FOLSPRINGB-152) Implement TESTCONTAINERS\_POSTGRES\_IMAGE
-* [FOLSPRINGS-165](https://folio-org.atlassian.net/browse/FOLSPRINGS-165) kafka.KafkaContainer, apache/kafka-native:3.8.0
+* [FOLSPRINGB-152](https://issues.folio.org/browse/FOLSPRINGB-152) Implement TESTCONTAINERS_POSTGRES_IMAGE
 ### folio-spring-system-user
 * [FOLSPRINGS-157](https://issues.folio.org/browse/FOLSPRINGS-157) Add missing property to authn client, to allow for `fail-on-unknown-properties` in consuming modules
 

--- a/folio-spring-testing/pom.xml
+++ b/folio-spring-testing/pom.xml
@@ -72,7 +72,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
-      <version>1.20.1</version>
     </dependency>
 
     <dependency>

--- a/folio-spring-testing/src/main/java/org/folio/spring/testing/extension/impl/KafkaContainerExtension.java
+++ b/folio-spring-testing/src/main/java/org/folio/spring/testing/extension/impl/KafkaContainerExtension.java
@@ -5,7 +5,7 @@ import static org.testcontainers.utility.DockerImageName.parse;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.testcontainers.kafka.KafkaContainer;
+import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -16,7 +16,7 @@ import org.testcontainers.utility.DockerImageName;
 public class KafkaContainerExtension implements BeforeAllCallback, AfterAllCallback {
 
   private static final String SPRING_PROPERTY_NAME = "spring.kafka.bootstrap-servers";
-  private static final DockerImageName KAFKA_IMAGE = parse("apache/kafka-native:3.8.0");
+  private static final DockerImageName KAFKA_IMAGE = parse("confluentinc/cp-kafka:5.5.3");
   private static final KafkaContainer CONTAINER = new KafkaContainer(KAFKA_IMAGE)
     .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
 

--- a/folio-spring-testing/src/test/java/org/folio/spring/testing/extension/impl/KafkaContainerExtensionTest.java
+++ b/folio-spring-testing/src/test/java/org/folio/spring/testing/extension/impl/KafkaContainerExtensionTest.java
@@ -13,7 +13,7 @@ class KafkaContainerExtensionTest {
   @Test
   void beforeAllAddSystemProperties_positive() {
     extension.beforeAll(null);
-    assertThat(System.getProperty("spring.kafka.bootstrap-servers")).contains(":");
+    assertThat(System.getProperty("spring.kafka.bootstrap-servers")).contains("PLAINTEXT://");
   }
 
   @Test


### PR DESCRIPTION
Reverts folio-org/folio-spring-support#177

In dependant modules there still will be the version that is provided by spring-boot-dependencies. This causes test failures with the exception:
`ExceptionInInitializerError: Exception java.lang.IllegalStateException: Failed to verify that image 'apache/kafka-native:3.8.0' is a compatible substitute for 'apache/kafka'. This generally means that you are trying to use an image that Testcontainers has not been designed to use.`

So I suggesting to revert this for now and waiting for the spring-boot-dependencies v3.4.0 release which will contain new version of testcontainers that supports this "apache/kafka-native:3.8.0"
