### PR TITLE
[FOLSPRINGS-169] Additional i18n methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 * [FOLSPRINGB-152](https://issues.folio.org/browse/FOLSPRINGB-152) Implement TESTCONTAINERS_POSTGRES_IMAGE
 * [FOLSPRINGS-166](https://folio-org.atlassian.net/browse/FOLSPRINGS-166) Upgrade classgraph dependency from 4.8.90 to 4.8.175 fixing CVE-2021-47621
 ### folio-spring-system-user
-* [FOLSPRINGS-157](https://issues.folio.org/browse/FOLSPRINGS-157) Add missing property to authn client, to allow for `fail-on-unknown-properties` in consuming modules 
+* [FOLSPRINGS-157](https://issues.folio.org/browse/FOLSPRINGS-157) Add missing property to authn client, to allow for `fail-on-unknown-properties` in consuming modules
 
 ### i18n submodule
 * [FOLSPRINGB-160](https://issues.folio.org/browse/FOLSPRINGB-160) Make translation service accept multiple keys

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,11 +4,12 @@
 * [FOLSPRINGB-152](https://issues.folio.org/browse/FOLSPRINGB-152) Implement TESTCONTAINERS_POSTGRES_IMAGE
 * [FOLSPRINGS-166](https://folio-org.atlassian.net/browse/FOLSPRINGS-166) Upgrade classgraph dependency from 4.8.90 to 4.8.175 fixing CVE-2021-47621
 ### folio-spring-system-user
-* [FOLSPRINGS-157](https://issues.folio.org/browse/FOLSPRINGS-157) Add missing property to authn client, to allow for `fail-on-unknown-properties` in consuming modules
+* [FOLSPRINGS-157](https://issues.folio.org/browse/FOLSPRINGS-157) Add missing property to authn client, to allow for `fail-on-unknown-properties` in consuming modules 
 
 ### i18n submodule
 * [FOLSPRINGB-160](https://issues.folio.org/browse/FOLSPRINGB-160) Make translation service accept multiple keys
 * [FOLSPRINGS-163](https://folio-org.atlassian.net/browse/FOLSPRINGS-163) Wrong Locale in TranslationService and TranslationMap
+* [FOLSPRINGS-169](https://folio-org.atlassian.net/browse/FOLSPRINGS-169) Add additional convenience methods for providing locales, timezones, and using non-predefined templates
 
 ## 8.1.0 2024-02-29
 * [FOLSPRINGB-144](https://issues.folio.org/browse/FOLSPRINGB-144) Add support for filtering by undefined field value

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationMap.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationMap.java
@@ -182,18 +182,18 @@ public final class TranslationMap {
 
     for (int i = 0; i < args.length; i += 2) {
       // Sadly, ICU formatting strings only support date formats with the old Date class :(
-      Object transformedValue =
-        switch (args[i + 1]) {
-          case Instant instant -> Date.from(instant);
-          case LocalDateTime date -> Date.from(date.atZone(zone).toInstant());
-          case OffsetDateTime date -> Date.from(date.toInstant());
-          // ICU will chop off the time, so the time we use is irrelevant
-          case LocalDate date -> Date.from(date.atStartOfDay(zone).toInstant());
-          // ICU will chop off the date, so the date we use is irrelevant
-          case LocalTime time -> Date.from(time.atDate(LocalDate.now()).atZone(zone).toInstant());
-          case OffsetTime time -> Date.from(time.atDate(LocalDate.now()).toInstant());
-          default -> args[i + 1];
-        };
+      Object transformedValue = switch (args[i + 1]) {
+        case Instant instant -> Date.from(instant);
+        case LocalDateTime date -> Date.from(date.atZone(zone).toInstant());
+        case OffsetDateTime date -> Date.from(date.toInstant());
+        case ZonedDateTime date -> Date.from(date.toInstant());
+        // ICU will chop off the time, so the time we use is irrelevant
+        case LocalDate date -> Date.from(date.atStartOfDay(zone).toInstant());
+        // ICU will chop off the date, so the date we use is irrelevant
+        case LocalTime time -> Date.from(time.atDate(LocalDate.now()).atZone(zone).toInstant());
+        case OffsetTime time -> Date.from(time.atDate(LocalDate.now()).toInstant());
+        default -> args[i + 1];
+      };
 
       map.put(args[i].toString(), transformedValue);
     }

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationMap.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationMap.java
@@ -132,10 +132,14 @@ public final class TranslationMap {
   /**
    * Check if a key exists in the translation map (or a fallback).
    *
-   * @param key
+   * @param key key to check for
    */
   public boolean hasKey(String key) {
-    return this.patterns.containsKey(key) || (this.fallback != null && this.fallback.hasKey(key));
+    if (this.patterns.containsKey(key)) {
+      return true;
+    }
+
+    return this.fallback != null && this.fallback.hasKey(key);
   }
 
   /**
@@ -148,11 +152,12 @@ public final class TranslationMap {
    * @return the formatted string
    */
   public String format(ZoneId zone, String key, Object... args) {
-    return format(zone, new MessageFormat(get(key)), buildArgs(zone, args));
+    return formatRaw(zone, new MessageFormat(get(key)), buildArgs(zone, args));
   }
 
   /**
-   * Like {@link #format(ZoneId, String, Object...)}, but uses a message format string rather than looking it up in the map
+   * Like {@link #format(ZoneId, String, Object...)}, but uses a message format string rather than
+   * looking it up in the map.
    *
    * @param zone the timezone to use for date formatting
    * @param format the format string
@@ -160,10 +165,10 @@ public final class TranslationMap {
    * @return the formatted string
    */
   public String formatString(ZoneId zone, String format, Object... args) {
-    return format(zone, new MessageFormat(format), buildArgs(zone, args));
+    return formatRaw(zone, new MessageFormat(format), buildArgs(zone, args));
   }
 
-  /** Build associative map to pass to {@link MessageFormat#format(String, Map)} */
+  /** Build associative map to pass to {@link MessageFormat#format(String, Map)}. */
   private static Map<String, Object> buildArgs(ZoneId zone, Object... args) {
     if (args.length % 2 != 0) {
       throw new IllegalArgumentException(
@@ -208,8 +213,8 @@ public final class TranslationMap {
     return map;
   }
 
-  /** Format a message */
-  private String format(ZoneId zone, MessageFormat message, Map<String, Object> args) {
+  /** Format a message. */
+  private String formatRaw(ZoneId zone, MessageFormat message, Map<String, Object> args) {
     message.setLocale(new ULocale("%s@timezone=%s".formatted(this.locale.toString(), zone.toString())));
     return message.format(args);
   }

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationMap.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationMap.java
@@ -168,7 +168,9 @@ public final class TranslationMap {
     return formatRaw(zone, new MessageFormat(format), buildArgs(zone, args));
   }
 
-  /** Build associative map to pass to {@link MessageFormat#format(String, Map)}. */
+  /**
+   * Build associative map to pass to {@link MessageFormat#format(String, Map)}.
+   */
   private static Map<String, Object> buildArgs(ZoneId zone, Object... args) {
     if (args.length % 2 != 0) {
       throw new IllegalArgumentException(

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationMap.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationMap.java
@@ -182,34 +182,20 @@ public final class TranslationMap {
 
     for (int i = 0; i < args.length; i += 2) {
       // Sadly, ICU formatting strings only support date formats with the old Date class :(
+      Object transformedValue =
+        switch (args[i + 1]) {
+          case Instant instant -> Date.from(instant);
+          case LocalDateTime date -> Date.from(date.atZone(zone).toInstant());
+          case OffsetDateTime date -> Date.from(date.toInstant());
+          // ICU will chop off the time, so the time we use is irrelevant
+          case LocalDate date -> Date.from(date.atStartOfDay(zone).toInstant());
+          // ICU will chop off the date, so the date we use is irrelevant
+          case LocalTime time -> Date.from(time.atDate(LocalDate.now()).atZone(zone).toInstant());
+          case OffsetTime time -> Date.from(time.atDate(LocalDate.now()).toInstant());
+          default -> args[i + 1];
+        };
 
-      if (args[i + 1] instanceof Instant instant) {
-        args[i + 1] = Date.from(instant);
-      }
-      if (args[i + 1] instanceof LocalDateTime date) {
-        args[i + 1] = Date.from(date.atZone(zone).toInstant());
-      }
-      if (args[i + 1] instanceof OffsetDateTime date) {
-        args[i + 1] = Date.from(date.toInstant());
-      }
-      if (args[i + 1] instanceof ZonedDateTime date) {
-        args[i + 1] = Date.from(date.toInstant());
-      }
-
-      // ICU will chop off the time, so the time we use is irrelevant
-      if (args[i + 1] instanceof LocalDate date) {
-        args[i + 1] = Date.from(date.atStartOfDay(zone).toInstant());
-      }
-
-      // ICU will chop off the date, so the date we use is irrelevant
-      if (args[i + 1] instanceof LocalTime time) {
-        args[i + 1] = Date.from(time.atDate(LocalDate.now()).atZone(zone).toInstant());
-      }
-      if (args[i + 1] instanceof OffsetTime time) {
-        args[i + 1] = Date.from(time.atDate(LocalDate.now()).toInstant());
-      }
-
-      map.put(args[i].toString(), args[i + 1]);
+      map.put(args[i].toString(), transformedValue);
     }
 
     return map;

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationMap.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/model/TranslationMap.java
@@ -181,19 +181,24 @@ public final class TranslationMap {
     Map<String, Object> map = new HashMap<>();
 
     for (int i = 0; i < args.length; i += 2) {
+      Object transformedValue = args[i + 1];
+
       // Sadly, ICU formatting strings only support date formats with the old Date class :(
-      Object transformedValue = switch (args[i + 1]) {
-        case Instant instant -> Date.from(instant);
-        case LocalDateTime date -> Date.from(date.atZone(zone).toInstant());
-        case OffsetDateTime date -> Date.from(date.toInstant());
-        case ZonedDateTime date -> Date.from(date.toInstant());
-        // ICU will chop off the time, so the time we use is irrelevant
-        case LocalDate date -> Date.from(date.atStartOfDay(zone).toInstant());
-        // ICU will chop off the date, so the date we use is irrelevant
-        case LocalTime time -> Date.from(time.atDate(LocalDate.now()).atZone(zone).toInstant());
-        case OffsetTime time -> Date.from(time.atDate(LocalDate.now()).toInstant());
-        default -> args[i + 1];
-      };
+      if (transformedValue instanceof Instant instant) {
+        transformedValue = Date.from(instant);
+      } else if (transformedValue instanceof LocalDateTime date) {
+        transformedValue = Date.from(date.atZone(zone).toInstant());
+      } else if (transformedValue instanceof OffsetDateTime date) {
+        transformedValue = Date.from(date.toInstant());
+      } else if (transformedValue instanceof ZonedDateTime date) {
+        transformedValue = Date.from(date.toInstant());
+      } else if (transformedValue instanceof LocalDate date) {
+        transformedValue = Date.from(date.atStartOfDay(zone).toInstant());
+      } else if (transformedValue instanceof LocalTime time) {
+        transformedValue = Date.from(time.atDate(LocalDate.now()).atZone(zone).toInstant());
+      } else if (transformedValue instanceof OffsetTime time) {
+        transformedValue = Date.from(time.atDate(LocalDate.now()).toInstant());
+      }
 
       map.put(args[i].toString(), transformedValue);
     }

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
@@ -103,14 +103,14 @@ public class TranslationService {
    * <p>Format an ICU format string (found by its key), supplying a series of named arguments as key
    * value pairs.  For example: {@code format("Hello {name}", "name", parameterValue)}.</p>
    *
-   * <p>Uses the current locale(s) and system timezone.</p>
+   * <p>Uses the current request's locale(s) and UTC.</p>
    *
    * @param key the key of the format string
    * @param args pairs of keys and values to interpolate
    * @return the formatted string
    */
   public String format(String key, Object... args) {
-    return format(getCurrentLocales(), ZoneId.systemDefault(), key, args);
+    return format(getCurrentLocales(), ZoneId.of("UTC"), key, args);
   }
 
   /**
@@ -122,7 +122,7 @@ public class TranslationService {
    * @return the formatted string
    */
   public String format(Collection<Locale> locales, String key, Object... args) {
-    return format(locales, ZoneId.systemDefault(), key, args);
+    return format(locales, ZoneId.of("UTC"), key, args);
   }
 
   /**

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
@@ -4,6 +4,7 @@ import com.ibm.icu.text.ListFormatter;
 import jakarta.annotation.Nonnull;
 import jakarta.annotation.Nullable;
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -78,9 +79,7 @@ public class TranslationService {
   public List<Locale> getCurrentLocales() {
     try {
       return Collections.list(
-        ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
-          .getRequest()
-          .getLocales()
+        ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest().getLocales()
       );
     } catch (IllegalStateException e) {
       log.warn("The current request contains no locale information: {}", e.getMessage());
@@ -97,25 +96,58 @@ public class TranslationService {
    * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language">MDN docs</a>
    */
   public Locale getCurrentLocale() {
-    return getCurrentLocales()
-      .stream()
-      .findFirst()
-      .orElse(configuration.getFallbackLocale());
+    return getCurrentLocales().stream().findFirst().orElse(configuration.getFallbackLocale());
   }
 
   /**
-   * Wraps the {@link TranslationMap#format TranslationMap#format} method on the current translation.
-   * Equivalent to {@code getCurrentTranslation().format(...)}.
-   *
    * <p>Format an ICU format string (found by its key), supplying a series of named arguments as key
-   * value pairs.  For example: {@code format("Hello {name}", "name", parameterValue)}</p>
+   * value pairs.  For example: {@code format("Hello {name}", "name", parameterValue)}.</p>
+   *
+   * <p>Uses the current locale(s) and system timezone.</p>
    *
    * @param key the key of the format string
    * @param args pairs of keys and values to interpolate
    * @return the formatted string
    */
   public String format(String key, Object... args) {
-    return getCurrentTranslation().format(key, args);
+    return format(getCurrentLocales(), ZoneId.systemDefault(), key, args);
+  }
+
+  /**
+   * The same as {@link #format(String, Object...) format}, but with specific locale(s).
+   *
+   * @param locales the locales to consider for formatting
+   * @param key the key of the format string
+   * @param args pairs of keys and values to interpolate
+   * @return the formatted string
+   */
+  public String format(Collection<Locale> locales, String key, Object... args) {
+    return format(locales, ZoneId.systemDefault(), key, args);
+  }
+
+  /**
+   * The same as {@link #format(String, Object...) format}, but with a specific timezone.
+   *
+   * @param zone the timezone to localize dates/times to
+   * @param key the key of the format string
+   * @param args pairs of keys and values to interpolate
+   * @return the formatted string
+   */
+  public String format(ZoneId zone, String key, Object... args) {
+    return format(getCurrentLocales(), zone, key, args);
+  }
+
+  /**
+   * The same as {@link #format(String, Object...) format}, but with specific locale(s) and timezone.
+   *
+   * @param locales the locales to consider for formatting
+   * @param zone the timezone to localize dates/times to
+   * @param key the key of the format string
+   * @param args pairs of keys and values to interpolate
+   * @return the formatted string
+   */
+  public String format(Collection<Locale> locales, ZoneId zone, String key, Object... args) {
+    return getBestTranslation(locales).format(zone, key, args);
   }
 
   /**
@@ -128,15 +160,37 @@ public class TranslationService {
   public String format(String[] keys, Object... args) {
     if (keys == null || keys.length == 0) {
       throw new IllegalStateException(
-        String.format("Keys must be provided for formatting, but provided %s", Arrays.toString(keys)));
+        String.format("Keys must be provided for formatting, but provided %s", Arrays.toString(keys))
+      );
     }
     for (String key : keys) {
-      var translation = format(key, args);
+      String translation = format(key, args);
       if (!translation.endsWith(key)) {
         return translation;
       }
     }
     return format(keys[0], args);
+  }
+
+  /**
+   * Check if a key exists in the translation map for the current locale (or a fallback).
+   *
+   * @param key the key to check
+   * @return true if the key exists in the translation map
+   */
+  public boolean hasKey(String key) {
+    return getCurrentTranslation().hasKey(key);
+  }
+
+  /**
+   * Check if a key exists in the translation map for a given set of locales (or their fallback).
+   *
+   * @param locales the locales to consider
+   * @param key the key to check
+   * @return true if the key exists in the translation map
+   */
+  public boolean hasKey(Collection<Locale> locales, String key) {
+    return getBestTranslation(locales).hasKey(key);
   }
 
   /**
@@ -176,10 +230,7 @@ public class TranslationService {
    *   default if neither are available
    */
   @Nullable
-  protected TranslationMap getTranslation(
-    Locale locale,
-    @Nullable TranslationMap fallback
-  ) {
+  protected TranslationMap getTranslation(Locale locale, @Nullable TranslationMap fallback) {
     return localeTranslations.computeIfAbsent(
       locale,
       (Locale missingLocale) -> {
@@ -195,11 +246,7 @@ public class TranslationService {
         TranslationMap baseMap = new TranslationMap(missingLocale, baseFile, fallback);
 
         if (languageMap.containsKey(missingLocale.getCountry().toLowerCase())) {
-          return new TranslationMap(
-            missingLocale,
-            languageMap.get(missingLocale.getCountry().toLowerCase()),
-            baseMap
-          );
+          return new TranslationMap(missingLocale, languageMap.get(missingLocale.getCountry().toLowerCase()), baseMap);
         }
 
         return baseMap;
@@ -227,10 +274,9 @@ public class TranslationService {
   protected TranslationMap resolveFallbackTranslation() {
     TranslationMap foundDefault = getTranslation(configuration.getFallbackLocale(), null);
     if (foundDefault == null) {
-      throw new IllegalStateException(String.format(
-        "No translations are sufficient for the default locale (%s)",
-        configuration.getFallbackLocale()
-      ));
+      throw new IllegalStateException(
+        String.format("No translations are sufficient for the default locale (%s)", configuration.getFallbackLocale())
+      );
     }
     return foundDefault;
   }
@@ -286,20 +332,13 @@ public class TranslationService {
   protected List<TranslationFile> getAvailableTranslationFiles() {
     try {
       Map<String, List<Resource>> localeGroups = Arrays
-        .stream(resourceResolver.getResources(
-          String.format(
-            TRANSLATIONS_CLASSPATH,
-            configuration.getTranslationDirectory()
-          )
-        ))
+        .stream(
+          resourceResolver.getResources(String.format(TRANSLATIONS_CLASSPATH, configuration.getTranslationDirectory()))
+        )
         .filter(Resource::isReadable)
         .collect(Collectors.groupingBy(Resource::getFilename));
 
-      List<TranslationFile> files = localeGroups
-        .values()
-        .stream()
-        .map(TranslationFile::new)
-        .toList();
+      List<TranslationFile> files = localeGroups.values().stream().map(TranslationFile::new).toList();
 
       log.info("Got translation files: " + files);
 

--- a/folio-spring-i18n/src/test/java/org/folio/spring/i18n/model/TranslationMapTest.java
+++ b/folio-spring-i18n/src/test/java/org/folio/spring/i18n/model/TranslationMapTest.java
@@ -5,8 +5,14 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.temporal.Temporal;
 import java.util.Arrays;
 import java.util.Locale;
 import java.util.stream.Stream;
@@ -21,43 +27,36 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 @UnitTest
 class TranslationMapTest {
 
-  static TranslationFile FILE_EN_CA;
-  static TranslationFile FILE_EN_BASE;
-  static TranslationFile FILE_FR_FR;
+  static final TranslationFile FILE_EN_CA;
+  static final TranslationFile FILE_EN_BASE;
+  static final TranslationFile FILE_FR_FR;
+
+  static final ZoneId UTC = ZoneId.of("UTC");
+  static final ZoneId EST = ZoneId.of("America/New_York");
+  static final ZoneId UTC_MINUS_12 = ZoneId.of("Etc/GMT+12"); // the sign is inverted intentionally
+  static final ZoneId UTC_PLUS_14 = ZoneId.of("Etc/GMT-14"); // the sign is inverted intentionally
 
   static {
     ResourcePatternResolver rr = new PathMatchingResourcePatternResolver();
     FILE_EN_CA =
       new TranslationFile(
         Arrays.asList(
-          rr.getResource(
-            "classpath:/test-translations/test-multiple/mod-bar/en_ca.json"
-          ),
-          rr.getResource(
-            "classpath:/test-translations/test-multiple/mod-foo/en_ca.json"
-          )
+          rr.getResource("classpath:/test-translations/test-multiple/mod-bar/en_ca.json"),
+          rr.getResource("classpath:/test-translations/test-multiple/mod-foo/en_ca.json")
         )
       );
     FILE_EN_BASE =
       new TranslationFile(
         Arrays.asList(
-          rr.getResource(
-            "classpath:/test-translations/test-multiple/mod-bar/en.json"
-          ),
-          rr.getResource(
-            "classpath:/test-translations/test-multiple/mod-foo/en.json"
-          )
+          rr.getResource("classpath:/test-translations/test-multiple/mod-bar/en.json"),
+          rr.getResource("classpath:/test-translations/test-multiple/mod-foo/en.json")
         )
       );
     FILE_FR_FR =
       new TranslationFile(
         Arrays.asList(
-          rr.getResource(
-            "classpath:/test-translations/test-multiple/mod-bar/fr_fr.json"
-          ),
-          rr.getResource(
-            "classpath:/test-translations/test-multiple/mod-foo/fr_fr.json"
-          )
+          rr.getResource("classpath:/test-translations/test-multiple/mod-bar/fr_fr.json"),
+          rr.getResource("classpath:/test-translations/test-multiple/mod-foo/fr_fr.json")
         )
       );
   }
@@ -75,44 +74,35 @@ class TranslationMapTest {
    */
   @Test
   void testFallbackFormat() {
-    TranslationMap englishBase = new TranslationMap(
-      Locale.FRANCE,
-      FILE_EN_BASE
-    );
-    TranslationMap englishCa = new TranslationMap(
-      Locale.FRANCE,
-      FILE_EN_CA,
-      englishBase
-    );
-    TranslationMap france = new TranslationMap(
-      Locale.FRANCE,
-      FILE_FR_FR,
-      englishCa
-    );
+    TranslationMap englishBase = new TranslationMap(Locale.FRANCE, FILE_EN_BASE);
+    TranslationMap englishCa = new TranslationMap(Locale.FRANCE, FILE_EN_CA, englishBase);
+    TranslationMap france = new TranslationMap(Locale.FRANCE, FILE_FR_FR, englishCa);
 
-    assertThat(
-      france.format("mod-foo.foo", "test", "bar"),
-      is("[mod-foo] fr_fr bar")
-    );
-    assertThat(
-      france.format("mod-bar.foo", "test", "bar"),
-      is("[mod-bar] fr_fr bar")
-    );
+    assertThat(france.format(UTC, "mod-foo.foo", "test", "bar"), is("[mod-foo] fr_fr bar"));
+    assertThat(france.format(UTC, "mod-bar.foo", "test", "bar"), is("[mod-bar] fr_fr bar"));
 
-    assertThat(france.format("mod-foo.en_only"), is("[mod-foo] In en_ca!"));
-    assertThat(
-      france.format("mod-foo.en_base_only"),
-      is("[mod-foo] In en base!")
-    );
-    assertThat(
-      france.format("mod-bar.en_base_only"),
-      is("[mod-bar] In en base!")
-    );
-    assertThat(france.format("thisDoesNotExist"), is("thisDoesNotExist"));
-    assertThat(
-      france.format("mod-foo.thisDoesNotExist"),
-      is("mod-foo.thisDoesNotExist")
-    );
+    assertThat(france.format(UTC, "mod-foo.en_only"), is("[mod-foo] In en_ca!"));
+    assertThat(france.format(UTC, "mod-foo.en_base_only"), is("[mod-foo] In en base!"));
+    assertThat(france.format(UTC, "mod-bar.en_base_only"), is("[mod-bar] In en base!"));
+    assertThat(france.format(UTC, "thisDoesNotExist"), is("thisDoesNotExist"));
+    assertThat(france.format(UTC, "mod-foo.thisDoesNotExist"), is("mod-foo.thisDoesNotExist"));
+  }
+
+  @Test
+  void testHasKey() {
+    TranslationMap englishBase = new TranslationMap(Locale.FRANCE, FILE_EN_BASE);
+    TranslationMap france = new TranslationMap(Locale.FRANCE, FILE_FR_FR, englishBase);
+
+    // present directly
+    assertThat(france.hasKey("mod-foo.foo"), is(true));
+    assertThat(englishBase.hasKey("mod-foo.en_base_only"), is(true));
+
+    // present by fallback only
+    assertThat(france.hasKey("mod-foo.en_base_only"), is(true));
+
+    // not present
+    assertThat(france.hasKey("thisDoesNotExist"), is(false));
+    assertThat(france.hasKey("mod-foo.thisDoesNotExist"), is(false));
   }
 
   @Test
@@ -121,6 +111,7 @@ class TranslationMapTest {
 
     assertThat(
       map.format(
+        UTC,
         "mod-foo.complex",
         "text",
         "placeholder",
@@ -135,6 +126,7 @@ class TranslationMapTest {
     );
     assertThat(
       map.format(
+        UTC,
         "mod-foo.complex",
         "text",
         "placeholder2",
@@ -152,30 +144,110 @@ class TranslationMapTest {
   static Stream<Arguments> testPlural() {
     // https://www.unicode.org/cldr/charts/45/supplemental/language_plural_rules.html#fr
     return Stream.of(
-        Arguments.of(Locale.FRENCH, FILE_FR_FR, 1, "1 jour"),
-        Arguments.of(Locale.FRENCH, FILE_FR_FR, 2, "2 jours"),
-        Arguments.of(Locale.FRENCH, FILE_FR_FR, 1_000_000, "1 000 000 de jours"),
-        Arguments.of(Locale.ENGLISH, FILE_EN_BASE, 1, "1 day"),
-        Arguments.of(Locale.ENGLISH, FILE_EN_BASE, 2, "2 days"),
-        Arguments.of(Locale.ENGLISH, FILE_EN_BASE, 1_000_000, "1,000,000 days")
-        );
+      Arguments.of(Locale.FRENCH, FILE_FR_FR, 1, "1 jour"),
+      Arguments.of(Locale.FRENCH, FILE_FR_FR, 2, "2 jours"),
+      Arguments.of(Locale.FRENCH, FILE_FR_FR, 1_000_000, "1 000 000 de jours"),
+      Arguments.of(Locale.ENGLISH, FILE_EN_BASE, 1, "1 day"),
+      Arguments.of(Locale.ENGLISH, FILE_EN_BASE, 2, "2 days"),
+      Arguments.of(Locale.ENGLISH, FILE_EN_BASE, 1_000_000, "1,000,000 days")
+    );
   }
 
   @ParameterizedTest
   @MethodSource
   void testPlural(Locale locale, TranslationFile translationFile, int i, String expected) {
     var map = new TranslationMap(locale, translationFile);
-    assertThat(map.format("mod-foo.days", "count", i), is(expected));
+    assertThat(map.format(UTC, "mod-foo.days", "count", i), is(expected));
   }
 
   @Test
-  void testBadFormat() {
+  void testBadFormatArgCount() {
     TranslationMap map = new TranslationMap(Locale.ENGLISH, FILE_EN_BASE);
 
     assertThrows(
       IllegalArgumentException.class,
-      () -> map.format("test", "non-matched key"),
+      () -> map.format(UTC, "test", "non-matched key"),
       "Every key must have a value"
     );
+  }
+
+  static Stream<Arguments> temporalDates() {
+    // input value, output time zone, expected output with format date/medium
+    return Stream.of(
+      // any time on Jan 1 should still be printed as Jan 1 in UTC
+      Arguments.of(Instant.parse("2024-01-01T00:00:00+00:00"), Locale.ENGLISH, UTC, "Jan 1, 2024"),
+      Arguments.of(Instant.parse("2024-01-01T16:00:00+00:00"), Locale.ENGLISH, UTC, "Jan 1, 2024"),
+      Arguments.of(Instant.parse("2024-01-01T23:59:59+00:00"), Locale.ENGLISH, UTC, "Jan 1, 2024"),
+      // EST is 5 hours behind UTC, so 4am on Jan 1 in UTC is Dec 31 in EST
+      Arguments.of(Instant.parse("2024-01-01T00:00:00+00:00"), Locale.ENGLISH, EST, "Dec 31, 2023"),
+      Arguments.of(Instant.parse("2024-01-01T04:00:00+00:00"), Locale.ENGLISH, EST, "Dec 31, 2023"),
+      Arguments.of(Instant.parse("2024-01-01T05:00:00+00:00"), Locale.ENGLISH, EST, "Jan 1, 2024"),
+      Arguments.of(Instant.parse("2024-01-01T23:59:59+00:00"), Locale.ENGLISH, EST, "Jan 1, 2024"),
+      // we should respect other languages' terms
+      Arguments.of(Instant.parse("2024-01-01T23:59:59+00:00"), Locale.FRENCH, UTC, "1 janv. 2024"),
+      // test other Temporals
+      // LocalDate
+      Arguments.of(LocalDate.of(2024, 1, 1), Locale.ENGLISH, UTC, "Jan 1, 2024"),
+      Arguments.of(LocalDate.of(2024, 1, 1), Locale.ENGLISH, EST, "Jan 1, 2024"),
+      Arguments.of(LocalDate.of(2024, 1, 1), Locale.ENGLISH, UTC_MINUS_12, "Jan 1, 2024"),
+      Arguments.of(LocalDate.of(2024, 1, 1), Locale.ENGLISH, UTC_PLUS_14, "Jan 1, 2024"),
+      // LocalDateTime
+      Arguments.of(LocalDateTime.of(2024, 1, 1, 0, 0), Locale.ENGLISH, UTC, "Jan 1, 2024"),
+      // OffsetDateTime
+      Arguments.of(LocalDateTime.of(2024, 1, 1, 0, 0).atOffset(ZoneOffset.UTC), Locale.ENGLISH, UTC, "Jan 1, 2024"),
+      Arguments.of(LocalDateTime.of(2024, 1, 1, 0, 0).atOffset(ZoneOffset.UTC), Locale.ENGLISH, EST, "Dec 31, 2023"),
+      // ZonedDateTime
+      Arguments.of(LocalDateTime.of(2024, 1, 1, 0, 0).atZone(UTC), Locale.ENGLISH, UTC, "Jan 1, 2024"),
+      Arguments.of(LocalDateTime.of(2024, 1, 1, 0, 0).atZone(UTC), Locale.ENGLISH, EST, "Dec 31, 2023")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("temporalDates")
+  void testTemporalAsDate(Temporal input, Locale locale, ZoneId timezone, String expected) {
+    TranslationMap map = new TranslationMap(locale, FILE_EN_BASE); // file doesn't do anything here
+    assertThat(map.formatString(timezone, "{test, date, medium}", "test", input), is(expected));
+  }
+
+  static Stream<Arguments> temporalTimes() {
+    // input value, output time zone, expected output with format time/medium
+    return Stream.of(
+      // any time on Jan 1 should still be printed as Jan 1 in UTC
+      Arguments.of(Instant.parse("2024-01-01T00:00:00+00:00"), Locale.ENGLISH, UTC, "12:00:00 AM"),
+      Arguments.of(Instant.parse("2024-01-01T16:00:00+00:00"), Locale.ENGLISH, UTC, "4:00:00 PM"),
+      Arguments.of(Instant.parse("2024-01-01T23:59:59+00:00"), Locale.ENGLISH, UTC, "11:59:59 PM"),
+      // EST is 5 hours behind UTC
+      Arguments.of(Instant.parse("2024-01-01T00:00:00+00:00"), Locale.ENGLISH, EST, "7:00:00 PM"),
+      Arguments.of(Instant.parse("2024-01-01T04:00:00+00:00"), Locale.ENGLISH, EST, "11:00:00 PM"),
+      Arguments.of(Instant.parse("2024-01-01T05:00:00+00:00"), Locale.ENGLISH, EST, "12:00:00 AM"),
+      Arguments.of(Instant.parse("2024-01-01T23:59:59+00:00"), Locale.ENGLISH, EST, "6:59:59 PM"),
+      // we should respect other locales' formatting/number systems (e.g. 24H)
+      Arguments.of(Instant.parse("2024-01-01T23:59:59+00:00"), Locale.FRENCH, UTC, "23:59:59"),
+      Arguments.of(Instant.parse("2024-01-01T23:59:59+00:00"), new Locale("ar"), UTC, "١١:٥٩:٥٩ م"),
+      // test other Temporals
+      // LocalDate
+      Arguments.of(LocalDate.of(2024, 1, 1), Locale.ENGLISH, UTC, "12:00:00 AM"),
+      Arguments.of(LocalDate.of(2024, 1, 1), Locale.ENGLISH, EST, "12:00:00 AM"),
+      // LocalDateTime
+      Arguments.of(LocalDateTime.of(2024, 1, 1, 5, 0), Locale.ENGLISH, UTC, "5:00:00 AM"),
+      // LocalTime
+      Arguments.of(LocalTime.of(5, 0), Locale.ENGLISH, UTC, "5:00:00 AM"),
+      Arguments.of(LocalTime.of(5, 0), Locale.ENGLISH, EST, "5:00:00 AM"),
+      // OffsetDateTime
+      Arguments.of(LocalDateTime.of(2024, 1, 1, 2, 0).atOffset(ZoneOffset.UTC), Locale.ENGLISH, UTC, "2:00:00 AM"),
+      Arguments.of(LocalDateTime.of(2024, 1, 1, 2, 0).atOffset(ZoneOffset.UTC), Locale.ENGLISH, EST, "9:00:00 PM"),
+      // OffsetTime
+      Arguments.of(OffsetTime.of(2, 0, 0, 0, ZoneOffset.UTC), Locale.ENGLISH, UTC, "2:00:00 AM"),
+      // ZonedDateTime
+      Arguments.of(LocalDateTime.of(2024, 1, 1, 2, 0).atZone(UTC), Locale.ENGLISH, UTC, "2:00:00 AM"),
+      Arguments.of(LocalDateTime.of(2024, 1, 1, 2, 0).atZone(UTC), Locale.ENGLISH, EST, "9:00:00 PM")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("temporalTimes")
+  void testTemporalAsTime(Temporal input, Locale locale, ZoneId timezone, String expected) {
+    TranslationMap map = new TranslationMap(locale, FILE_EN_BASE); // file doesn't do anything here
+    assertThat(map.formatString(timezone, "{test, time, medium}", "test", input), is(expected));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
 
   <properties>
     <java.version>17</java.version>
-
     <spring-boot.version>3.3.4</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
     <spring-cloud-starter-openfeign.version>4.1.3</spring-cloud-starter-openfeign.version>
     <maven-compat.version>3.9.9</maven-compat.version>
@@ -267,9 +266,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <release>${java.version}</release>
-          <annotationProcessorPaths>
+          <configuration>
+            <release>${java.version}</release>
+            <annotationProcessorPaths>
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,10 @@
 
   <properties>
     <java.version>17</java.version>
+
+    <!-- Used for pattern matching in switch, should be removed at 21 -->
+    <java.compilerArgs>--enable-preview</java.compilerArgs>
+
     <spring-boot.version>3.3.4</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
     <spring-cloud-starter-openfeign.version>4.1.3</spring-cloud-starter-openfeign.version>
     <maven-compat.version>3.9.9</maven-compat.version>
@@ -190,6 +194,7 @@
           <configuration>
             <useSystemClassLoader>false</useSystemClassLoader>
             <groups>unit</groups>
+            <argLine>${java.compilerArgs}</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -266,11 +271,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <release>${java.version}</release>
-            <!-- Used for pattern matching in switch, should be removed at 21 -->
-            <compilerArgs>--enable-preview</compilerArgs>
-            <annotationProcessorPaths>
+        <configuration>
+          <release>${java.version}</release>
+          <compilerArgs>${java.compilerArgs}</compilerArgs>
+          <annotationProcessorPaths>
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
@@ -322,6 +326,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <additionalJOptions>${java.compilerArgs}</additionalJOptions>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,6 @@
   <properties>
     <java.version>17</java.version>
 
-    <!-- Used for pattern matching in switch, should be removed at 21 -->
-    <java.compilerArgs>--enable-preview</java.compilerArgs>
-
     <spring-boot.version>3.3.4</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
     <spring-cloud-starter-openfeign.version>4.1.3</spring-cloud-starter-openfeign.version>
     <maven-compat.version>3.9.9</maven-compat.version>
@@ -194,7 +191,6 @@
           <configuration>
             <useSystemClassLoader>false</useSystemClassLoader>
             <groups>unit</groups>
-            <argLine>${java.compilerArgs}</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -273,7 +269,6 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
           <release>${java.version}</release>
-          <compilerArgs>${java.compilerArgs}</compilerArgs>
           <annotationProcessorPaths>
             <path>
               <groupId>org.projectlombok</groupId>
@@ -326,9 +321,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-          <additionalJOptions>${java.compilerArgs}</additionalJOptions>
-        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
             <release>${java.version}</release>
+            <!-- Used for pattern matching in switch, should be removed at 21 -->
+            <compilerArgs>--enable-preview</compilerArgs>
             <annotationProcessorPaths>
             <path>
               <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
# [Jira FOLSPRINGS-169](https://folio-org.atlassian.net/browse/FOLSPRINGS-169)

## Purpose
This adds a series of convenience methods for i18n, particularly for providing custom locales and timezones. Locales are typically guessed by the request context, however, this is not always available (for example, in background tasks), so a failsafe is nice.

Additionally, there is currently no way to get a user's timezone based on headers, so we don't have a way for `folio-spring-i18n` to guess the user's timezone. As such, we are now also providing methods for custom timezones to be passed in (and, if none is provided, the system time will be used, as was the previous default).

It may be worthwhile to consider API calls to mod-configuration to get the tenant's locale settings in the future, but that is well outside the scope of this ticket.

## Approach
The timezone part was a bit tricky, as `icu4j` doesn't readily expose setters for this when formatting messages. However, we can pass it an icu-specific `ULocale` which allows us to pass regular locale information (lang/region), plus parameters (including the `timezone`).

## Full list of added methods:

#### `TranslationService`
- `String format(Collection<Locale> locales, String key, Object... args)`
- `String format(ZoneId zone, String key, Object... args)`
- `String format(Collection<Locale> locales, ZoneId zone, String key, Object... args)`
- `boolean hasKey(String key)`
- `boolean hasKey(Collection<Locale> locales, String key)`

#### `TranslationMap`
- `boolean hasKey(String key)`
- `String format(ZoneId zone, String key, Object... args)`
  - ⚠️ replaces `String format(String key, Object... args)`
  - non-breaking since `TranslationMap` is never exposed for consumption outside this library
- `String formatString(ZoneId zone, String format, Object... args)`

#### TODOS and Open Questions
- [x] Update NEWS.md.