### PR TITLE
[FOLSPRINGS-171] i18n Use concurrent maps and synchronized methods where necessary

### DIFF
--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
@@ -242,7 +242,7 @@ public class TranslationService {
   @Nonnull
   protected Map<String, Map<String, TranslationFile>> getFileMap() {
     if (this.translationFileFromLanguageCountryMap == null) {
-      synchronized (this.translationFileFromLanguageCountryMap) {
+      synchronized (this) {
         if (this.translationFileFromLanguageCountryMap == null) {
           this.translationFileFromLanguageCountryMap = buildLanguageCountryPatternMap();
         }
@@ -318,7 +318,7 @@ public class TranslationService {
    *
    * @return the default locale's translation map
    */
-  protected synchronized TranslationMap getFallbackTranslation() {
+  protected TranslationMap getFallbackTranslation() {
     // computeIfAbsent does not work due to the resolver potentially filling multiple keys
     if (!this.localeTranslations.containsKey(configuration.getFallbackLocale())) {
       this.localeTranslations.put(configuration.getFallbackLocale(), resolveFallbackTranslation());

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -62,7 +63,7 @@ public class TranslationService {
   /**
    * A map from locales to translations, filled in on-demand as locales are presented.
    */
-  protected Map<Locale, TranslationMap> localeTranslations = new HashMap<>();
+  protected Map<Locale, TranslationMap> localeTranslations = new ConcurrentHashMap<>();
 
   private final ResourcePatternResolver resourceResolver;
   private final TranslationConfiguration configuration;
@@ -239,7 +240,7 @@ public class TranslationService {
    * @return the map of languages to countries to {@link TranslationFile TranslationFile}s
    */
   @Nonnull
-  protected Map<String, Map<String, TranslationFile>> getFileMap() {
+  protected synchronized Map<String, Map<String, TranslationFile>> getFileMap() {
     if (this.translationFileFromLanguageCountryMap == null) {
       this.translationFileFromLanguageCountryMap = buildLanguageCountryPatternMap();
     }
@@ -313,7 +314,7 @@ public class TranslationService {
    *
    * @return the default locale's translation map
    */
-  protected TranslationMap getFallbackTranslation() {
+  protected synchronized TranslationMap getFallbackTranslation() {
     // computeIfAbsent does not work due to the resolver potentially filling multiple keys
     if (!this.localeTranslations.containsKey(configuration.getFallbackLocale())) {
       this.localeTranslations.put(configuration.getFallbackLocale(), resolveFallbackTranslation());

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
@@ -243,9 +243,7 @@ public class TranslationService {
   protected Map<String, Map<String, TranslationFile>> getFileMap() {
     if (this.translationFileFromLanguageCountryMap == null) {
       synchronized (this) {
-        if (this.translationFileFromLanguageCountryMap == null) {
-          this.translationFileFromLanguageCountryMap = buildLanguageCountryPatternMap();
-        }
+        this.translationFileFromLanguageCountryMap = buildLanguageCountryPatternMap();
       }
     }
     return this.translationFileFromLanguageCountryMap;

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
@@ -240,9 +240,13 @@ public class TranslationService {
    * @return the map of languages to countries to {@link TranslationFile TranslationFile}s
    */
   @Nonnull
-  protected synchronized Map<String, Map<String, TranslationFile>> getFileMap() {
+  protected Map<String, Map<String, TranslationFile>> getFileMap() {
     if (this.translationFileFromLanguageCountryMap == null) {
-      this.translationFileFromLanguageCountryMap = buildLanguageCountryPatternMap();
+      synchronized (this.translationFileFromLanguageCountryMap) {
+        if (this.translationFileFromLanguageCountryMap == null) {
+          this.translationFileFromLanguageCountryMap = buildLanguageCountryPatternMap();
+        }
+      }
     }
     return this.translationFileFromLanguageCountryMap;
   }


### PR DESCRIPTION
There is a potential for concurrent modifications to `localeTranslations` within the `TranslationService` if multiple format requests are issued simultaneously and the cache is empty. This PR properly uses a `ConcurrentHashMap` and synchronizes the necessary methods.