### PR TITLE
FOLSPRINGS-174 - x-okapi-tenant header duplication

### DIFF
--- a/folio-spring-base/src/main/java/org/folio/spring/utils/FolioExecutionContextUtils.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/utils/FolioExecutionContextUtils.java
@@ -1,0 +1,31 @@
+package org.folio.spring.utils;
+
+import static org.folio.spring.integration.XOkapiHeaders.TENANT;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.SerializationUtils;
+import org.folio.spring.DefaultFolioExecutionContext;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+
+@Log4j2
+@UtilityClass
+public class FolioExecutionContextUtils {
+  public static FolioExecutionContext prepareContextForTenant(String tenantId, FolioModuleMetadata folioModuleMetadata,
+    FolioExecutionContext context) {
+    if (MapUtils.isNotEmpty(context.getOkapiHeaders())) {
+      // create deep copy of headers in order to make switching context thread safe
+      var headersCopy = SerializationUtils.clone((HashMap<String, Collection<String>>) context.getAllHeaders());
+      headersCopy.entrySet().removeIf(e -> TENANT.equalsIgnoreCase(e.getKey()));
+      headersCopy.put(TENANT, List.of(tenantId));
+      log.info("FOLIO context initialized with tenant {}", tenantId);
+      return new DefaultFolioExecutionContext(folioModuleMetadata, headersCopy);
+    }
+    throw new IllegalStateException("Okapi headers not provided");
+  }
+}

--- a/folio-spring-base/src/test/java/org/folio/spring/utils/FolioExecutionContextUtilsTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/utils/FolioExecutionContextUtilsTest.java
@@ -1,0 +1,44 @@
+package org.folio.spring.utils;
+
+import static java.util.Collections.singleton;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.spring.integration.XOkapiHeaders.TENANT;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.folio.spring.DefaultFolioExecutionContext;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+import org.junit.jupiter.api.Test;
+
+class FolioExecutionContextUtilsTest {
+  @Test
+  void testPrepareContextForTenant() {
+    var moduleMetadata = new FolioModuleMetadata() {
+      @Override public String getModuleName() {
+        return "test";
+      }
+
+      @Override public String getDBSchemaName(String tenantId) {
+        return "tenant_test";
+      }
+    };
+    var tenant = "tenant";
+    var newTenant = "new_tenant";
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put(TENANT, singleton(tenant));
+    var folioContext = new DefaultFolioExecutionContext(moduleMetadata, headers);
+
+    var actual = FolioExecutionContextUtils.prepareContextForTenant(newTenant, moduleMetadata, folioContext);
+
+    Consumer<FolioExecutionContext> contextRequirements = context -> {
+      assertThat(context.getFolioModuleMetadata()).isEqualTo(moduleMetadata);
+      assertThat(context.getOkapiHeaders()).containsOnlyKeys(TENANT);
+      assertThat(context.getOkapiHeaders().get(TENANT)).containsOnly(newTenant);
+    };
+
+    assertThat(actual).satisfies(contextRequirements);
+  }
+}

--- a/folio-spring-base/src/test/java/org/folio/spring/utils/FolioExecutionContextUtilsTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/utils/FolioExecutionContextUtilsTest.java
@@ -12,8 +12,10 @@ import java.util.function.Consumer;
 import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;
 
+@UnitTest
 class FolioExecutionContextUtilsTest {
   private final FolioModuleMetadata moduleMetadata = new FolioModuleMetadata() {
     @Override public String getModuleName() {

--- a/folio-spring-base/src/test/java/org/folio/spring/utils/FolioExecutionContextUtilsTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/utils/FolioExecutionContextUtilsTest.java
@@ -3,6 +3,7 @@ package org.folio.spring.utils;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -14,17 +15,18 @@ import org.folio.spring.FolioModuleMetadata;
 import org.junit.jupiter.api.Test;
 
 class FolioExecutionContextUtilsTest {
+  private final FolioModuleMetadata moduleMetadata = new FolioModuleMetadata() {
+    @Override public String getModuleName() {
+      return "test";
+    }
+
+    @Override public String getDBSchemaName(String tenantId) {
+      return "tenant_test";
+    }
+  };
+
   @Test
   void testPrepareContextForTenant() {
-    var moduleMetadata = new FolioModuleMetadata() {
-      @Override public String getModuleName() {
-        return "test";
-      }
-
-      @Override public String getDBSchemaName(String tenantId) {
-        return "tenant_test";
-      }
-    };
     var tenant = "tenant";
     var newTenant = "new_tenant";
     Map<String, Collection<String>> headers = new HashMap<>();
@@ -40,5 +42,15 @@ class FolioExecutionContextUtilsTest {
     };
 
     assertThat(actual).satisfies(contextRequirements);
+  }
+
+  @Test
+  void testPrepareContextForEmptyHeaders() {
+    var headers = new HashMap<String, Collection<String>>();
+    var folioContext = new DefaultFolioExecutionContext(moduleMetadata, headers);
+    var newTenant = "new_tenant";
+
+    assertThrows(IllegalStateException.class,
+      () -> FolioExecutionContextUtils.prepareContextForTenant(newTenant, moduleMetadata, folioContext));
   }
 }


### PR DESCRIPTION
[FOLSPRINGS-174](https://folio-org.atlassian.net/browse/FOLSPRINGS-174) - x-okapi-tenant header duplication

## Purpose
Implement a case-insensitivity check for the x-okapi-tenant header to prevent duplication.

## Approach
* Implemented FolioExecutionContextUtils to set up context for tenant
* Added unit test
