### PR TITLE
FOLSPRINGS-181: Upgrade Spring Boot from 3.3.4 to 3.3.6 fixing vulns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 8.2.2
+* [FOLSPRINGS-181](https://folio-org.atlassian.net/browse/FOLSPRINGS-181) Upgrade Spring Boot from 3.3.4 to 3.3.6 fixing vulns
+
 ## 8.2.1 2024-10-31
 * [FOLSPRINGS-171](https://folio-org.atlassian.net/browse/FOLSPRINGS-171) i18n Use concurrent maps and synchronized methods where necessary
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.3.4</version> <!-- also change spring-boot.version -->
+    <version>3.3.6</version> <!-- also change spring-boot.version -->
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -30,7 +30,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <spring-boot.version>3.3.4</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
+    <spring-boot.version>3.3.6</spring-boot.version> <!-- also change spring-boot-starter-parent version above -->
     <spring-cloud-starter-openfeign.version>4.1.3</spring-cloud-starter-openfeign.version>
     <maven-compat.version>3.9.9</maven-compat.version>
     <jackson-databind-nullable.version>0.2.6</jackson-databind-nullable.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLSPRINGS-181

## Purpose
This fixes multiple security vulnerabilities:

* https://www.cve.org/CVERecord?id=CVE-2024-52316 tomcat-embed-core Uncaught Exception
* https://www.cve.org/CVERecord?id=CVE-2024-38819 spring-webmvc Path Traversal
* https://www.cve.org/CVERecord?id=CVE-2024-52317 tomcat-embed-core Inadequate Encryption Strength
* https://www.cve.org/CVERecord?id=CVE-2024-38827 spring-security-crypto Authorization Bypass
* https://www.cve.org/CVERecord?id=CVE-2024-38820 spring-* Improper Handling of Case Sensitivity

## Approach
Upgrade Spring Boot from 3.3.4 to 3.3.6 in the release/8.2 Ramsons branch

#### TODOS and Open Questions
- [x] Update NEWS.md.