### PR TITLE
[FOLSPRINGS-183] Fix initialization when system user is disabled

### DIFF
--- a/folio-spring-system-user/src/main/java/org/folio/spring/config/OptionalSystemUserConfig.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/config/OptionalSystemUserConfig.java
@@ -2,11 +2,13 @@ package org.folio.spring.config;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.client.AuthnClient;
 import org.folio.spring.client.UsersClient;
 import org.folio.spring.config.properties.FolioEnvironment;
 import org.folio.spring.context.ExecutionContextBuilder;
 import org.folio.spring.model.SystemUser;
+import org.folio.spring.service.PrepareSystemUserService;
 import org.folio.spring.service.SystemUserProperties;
 import org.folio.spring.service.SystemUserService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -33,5 +35,11 @@ public class OptionalSystemUserConfig {
       AuthnClient authnClient, UsersClient usersClient) {
     return new SystemUserService(executionContextBuilder, systemUserProperties, folioEnvironment,
       authnClient, usersClient);
+  }
+
+  @Bean
+  public PrepareSystemUserService prepareSystemUserService(FolioExecutionContext executionContext,
+      SystemUserProperties systemUserProperties, SystemUserService systemUserService) {
+    return new PrepareSystemUserService(executionContext, systemUserProperties, systemUserService);
   }
 }

--- a/folio-spring-system-user/src/main/java/org/folio/spring/config/SystemUserConfig.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/config/SystemUserConfig.java
@@ -1,10 +1,18 @@
 package org.folio.spring.config;
 
+import lombok.extern.log4j.Log4j2;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.service.PrepareSystemUserService;
 import org.folio.spring.service.SystemUserProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 
+@Log4j2
 @Configuration
 @ComponentScan(basePackages = {
   "org.folio.spring.client",
@@ -13,4 +21,14 @@ import org.springframework.context.annotation.Configuration;
   "org.folio.spring.config.properties",
 })
 @EnableConfigurationProperties({SystemUserProperties.class})
-public class SystemUserConfig {}
+public class SystemUserConfig {
+
+  @Bean
+  @Lazy
+  @Order(Ordered.HIGHEST_PRECEDENCE)
+  public PrepareSystemUserService fallbackSystemUserService(FolioExecutionContext executionContext,
+      SystemUserProperties systemUserProperties) {
+    log.warn("Fallback system user service is being initialized; the system user is disabled.");
+    return new PrepareSystemUserService(executionContext, systemUserProperties, null);
+  }
+}

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/PrepareSystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/PrepareSystemUserService.java
@@ -24,10 +24,8 @@ import org.folio.spring.client.UsersClient;
 import org.folio.spring.client.UsersClient.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.stereotype.Service;
 
 @Log4j2
-@Service
 @RequiredArgsConstructor
 public class PrepareSystemUserService {
 

--- a/folio-spring-system-user/src/test/java/org/folio/spring/config/SystemUserConfigTest.java
+++ b/folio-spring-system-user/src/test/java/org/folio/spring/config/SystemUserConfigTest.java
@@ -1,0 +1,31 @@
+package org.folio.spring.config;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.service.PrepareSystemUserService;
+import org.folio.spring.service.SystemUserProperties;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@UnitTest
+class SystemUserConfigTest {
+
+  @Mock
+  private FolioExecutionContext folioExecutionContext;
+
+  @Test
+  void testFallbackPrepareSystemUserServiceDoesNothing() {
+    SystemUserProperties systemUserProperties = new SystemUserProperties();
+    systemUserProperties.setEnabled(false);
+
+    PrepareSystemUserService systemUserService = new SystemUserConfig()
+      .fallbackSystemUserService(folioExecutionContext, systemUserProperties);
+
+    assertDoesNotThrow(systemUserService::setupSystemUser);
+  }
+}


### PR DESCRIPTION
https://jenkins-aws.indexdata.com/job/folio-org/job/mod-roles-keycloak/job/master/180/consoleFull displayed an issue in tests where build failed if the system user was disabled, due to a lack of a `SystemUserService`. This is due to our `OptionalSystemUserConfig` which only provides the `systemUserService` bean iff the system user is enabled, however, #220 added it as a required bean for initialization of `PrepareSystemUserService`, a bean which is provided in all contexts.

This provides a fallback for this case, creating a `PrepareSystemUserService` with a missing `SystemUserService`, as it is not needed when there is no system user work to do.

I could have used an `ObjectProvider` or `Optional` directly in `PrepareSystemUserService` instead, however, I opted for the extra configuration bean to keep the conditional bean logic in one place and to provide an error message for this case.