### PR TITLE
FOLSPRINGS-185 Implement case insensitive accents ignoring CQL queries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 ## 9.0.0 In progress
 
-Breaking change, new default: A CQL search in a `String` field ignores case (= is case insensitive) and ignores accents by default; this is for consistency with <a href="https://github.com/folio-org/raml-module-builder?tab=readme-ov-file#the-post-tenant-api">RMB based modules</a>. Use the annotations `@RespectCase` and/or `@RespectAccents` in the entity class to change this new default.
+Breaking change, new default: A CQL search in a `String` field ignores case (= is case insensitive) and ignores accents by default; this is for consistency with <a href="https://github.com/folio-org/raml-module-builder?tab=readme-ov-file#the-post-tenant-api">RMB based modules</a>. Use the annotations `@RespectCase` and/or `@RespectAccents` in the entity class to change this new default. Update database indices accordingly, for example:
+
+```
+DROP INDEX IF EXISTS idx_medreq_requester_barcode;
+CREATE INDEX idx_medreq_requester_barcode ON ${database.defaultSchemaName}.mediated_request(lower(f_unaccent(requester_barcode)));
+```
 
 * [FOLSPRINGS-188](https://folio-org.atlassian.net/browse/FOLSPRINGS-188) Upgrade to Java 21
 * [FOLSPRINGS-178](https://folio-org.atlassian.net/browse/FOLSPRINGS-178) spring-cloud-starter-openfeign 4.1.4 fixing spring-security-crypto Authorization Bypass

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
-## 8.3.0 In progress
+## 9.0.0 In progress
+
+Breaking change, new default: A CQL search in a `String` field ignores case (= is case insensitive) and ignores accents by default; this is for consistency with <a href="https://github.com/folio-org/raml-module-builder?tab=readme-ov-file#the-post-tenant-api">RMB based modules</a>. Use the annotations `@RespectCase` and/or `@RespectAccents` in the entity class to change this new default.
+
 * [FOLSPRINGS-178](https://folio-org.atlassian.net/browse/FOLSPRINGS-178) spring-cloud-starter-openfeign 4.1.4 fixing spring-security-crypto Authorization Bypass
+
+### cql submodule
+* [FOLSPRINGS-185](https://folio-org.atlassian.net/browse/FOLSPRINGS-185) Implement case insensitive accents ignoring CQL queries
 
 ### folio-spring-system-user
 * [FOLSPRINGS-180](https://folio-org.atlassian.net/browse/FOLSPRINGS-180) Token expiration off by 1 minute in test

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ public interface JpaCqlRepository<T, ID> extends JpaRepository<T, ID> {
 }
 ```
 
+By default a CQL search a `String` field ignores case (= is case insensitive) and ignores accents; this is for consistency with <a href="https://github.com/folio-org/raml-module-builder?tab=readme-ov-file#the-post-tenant-api">RMB based modules</a>. Use the annotations `@RespectCase` and/or `@RespectAccents` in the entity class to change the default.
+
 ## Logging
 
 ### Default logging format

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
@@ -393,7 +393,7 @@ public class Cql2JpaCriteria<E> {
   private Predicate queryByLike(Path<String> field0, String term0, String comparator,
                                 CriteriaBuilder cb) {
 
-    var wrapper = wrapper(field0, cb);
+    var wrapper = wrapper(cb);
     var field = wrapper.apply(field0);
     var term = wrapper.apply(cb.literal(cql2like(term0)));
     if (NOT_EQUALS_OPERATOR.equals(comparator)) {
@@ -411,12 +411,9 @@ public class Cql2JpaCriteria<E> {
   }
 
   /**
-   * Wrap the field with functions lower and/or f_unaccent as needed.
+   * A wrapper with functions lower and/or f_unaccent as needed for {@link #domainClass}.
    */
-  private UnaryOperator<Expression<String>> wrapper(Expression<String> field, CriteriaBuilder cb) {
-    if (!field.getJavaType().equals(String.class)) {
-      return UnaryOperator.identity();
-    }
+  private UnaryOperator<Expression<String>> wrapper(CriteriaBuilder cb) {
     var respectAccents = domainClass.getAnnotation(RespectAccents.class) != null;
     var respectCase = domainClass.getAnnotation(RespectCase.class) != null;
     if (respectAccents) {
@@ -438,14 +435,14 @@ public class Cql2JpaCriteria<E> {
    * Create an SQL expression using SQL as is syntax.
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
-  private Predicate queryBySql(Expression field, Comparable term, String comparator,
+  Predicate queryBySql(Expression field, Comparable term, String comparator,
       CriteriaBuilder cb) throws QueryValidationException {
 
     var value = (String) term;
     var javaType = field.getJavaType();
 
     if (String.class.equals(javaType)) {
-      UnaryOperator<Expression<String>> wrapper = wrapper(field, cb);
+      UnaryOperator<Expression<String>> wrapper = wrapper(cb);
       field = wrapper.apply(field);
       var termExpression = wrapper.apply(cb.literal(cql2like(term.toString())));
       return toPredicate(field, termExpression, comparator, cb);

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
@@ -280,20 +280,24 @@ public class Cql2JpaCriteria<E> {
     String comparator, CriteriaBuilder cb, boolean ignoreCase) throws QueryValidationException {
     return switch (comparator) {
       case ">" -> ignoreCase && field.getJavaType().equals(String.class)
-        ? cb.notEqual(cb.lower(field.as(String.class)), value.toString().toLowerCase())
+        ? cb.greaterThan(cb.lower(field.as(String.class)), cb.lower(cb.literal(value.toString())))
         : cb.greaterThan(field, value);
-      case "<" -> cb.lessThan(field, value);
+      case "<" ->
+        ignoreCase && field.getJavaType().equals(String.class)
+        ? cb.lessThan(cb.lower(field.as(String.class)), cb.lower(cb.literal(value.toString())))
+        :
+          cb.lessThan(field, value);
       case ">=" -> ignoreCase && field.getJavaType().equals(String.class)
-        ? cb.notEqual(cb.lower(field.as(String.class)), value.toString().toLowerCase())
+        ? cb.greaterThanOrEqualTo(cb.lower(field.as(String.class)), cb.lower(cb.literal(value.toString())))
         : cb.greaterThanOrEqualTo(field, value);
       case "<=" -> ignoreCase && field.getJavaType().equals(String.class)
-        ? cb.notEqual(cb.lower(field.as(String.class)), value.toString().toLowerCase())
+        ? cb.lessThanOrEqualTo(cb.lower(field.as(String.class)), cb.lower(cb.literal(value.toString())))
         : cb.lessThanOrEqualTo(field, value);
       case "==", "=" -> ignoreCase && field.getJavaType().equals(String.class)
-        ? cb.equal(cb.lower(field.as(String.class)), value.toString().toLowerCase())
+        ? cb.equal(cb.lower(field.as(String.class)), cb.lower(cb.literal(value.toString())))
         : cb.equal(field, value);
       case NOT_EQUALS_OPERATOR -> ignoreCase && field.getJavaType().equals(String.class)
-        ? cb.notEqual(cb.lower(field.as(String.class)), value.toString().toLowerCase())
+        ? cb.notEqual(cb.lower(field.as(String.class)), cb.lower(cb.literal(value.toString())))
         : cb.notEqual(field, value);
       default -> throw new QueryValidationException(
         "CQL: Unsupported operator '"
@@ -379,11 +383,11 @@ public class Cql2JpaCriteria<E> {
                                 CriteriaBuilder cb, boolean ignoreCase) {
     if (NOT_EQUALS_OPERATOR.equals(comparator)) {
       return ignoreCase
-        ? cb.notLike(cb.lower(field), cql2like(term).toLowerCase(), '\\')
+        ? cb.notLike(cb.lower(field), cb.lower(cb.literal(cql2like(term))), '\\')
         : cb.notLike(field, cql2like(term), '\\');
     } else {
       return ignoreCase
-        ? cb.like(cb.lower(field), cql2like(term).toLowerCase(), '\\')
+        ? cb.like(cb.lower(field), cb.lower(cb.literal(cql2like(term))), '\\')
         : cb.like(field, cql2like(term), '\\');
     }
   }

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
@@ -279,10 +279,16 @@ public class Cql2JpaCriteria<E> {
   private static <G extends Comparable<? super G>> Predicate toPredicate(Expression<G> field, G value,
     String comparator, CriteriaBuilder cb, boolean ignoreCase) throws QueryValidationException {
     return switch (comparator) {
-      case ">" -> cb.greaterThan(field, value);
+      case ">" -> ignoreCase && field.getJavaType().equals(String.class)
+        ? cb.notEqual(cb.lower(field.as(String.class)), value.toString().toLowerCase())
+        : cb.greaterThan(field, value);
       case "<" -> cb.lessThan(field, value);
-      case ">=" -> cb.greaterThanOrEqualTo(field, value);
-      case "<=" -> cb.lessThanOrEqualTo(field, value);
+      case ">=" -> ignoreCase && field.getJavaType().equals(String.class)
+        ? cb.notEqual(cb.lower(field.as(String.class)), value.toString().toLowerCase())
+        : cb.greaterThanOrEqualTo(field, value);
+      case "<=" -> ignoreCase && field.getJavaType().equals(String.class)
+        ? cb.notEqual(cb.lower(field.as(String.class)), value.toString().toLowerCase())
+        : cb.lessThanOrEqualTo(field, value);
       case "==", "=" -> ignoreCase && field.getJavaType().equals(String.class)
         ? cb.equal(cb.lower(field.as(String.class)), value.toString().toLowerCase())
         : cb.equal(field, value);

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
@@ -373,11 +373,11 @@ public class Cql2JpaCriteria<E> {
                                 CriteriaBuilder cb, boolean ignoreCase) {
     if (NOT_EQUALS_OPERATOR.equals(comparator)) {
       return ignoreCase
-        ? cb.notLike(cb.lower(field), cql2like(term).toLowerCase())
+        ? cb.notLike(cb.lower(field), cql2like(term).toLowerCase(), '\\')
         : cb.notLike(field, cql2like(term), '\\');
     } else {
       return ignoreCase
-        ? cb.like(cb.lower(field), cql2like(term).toLowerCase())
+        ? cb.like(cb.lower(field), cql2like(term).toLowerCase(), '\\')
         : cb.like(field, cql2like(term), '\\');
     }
   }

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
@@ -68,14 +68,14 @@ public class Cql2JpaCriteria<E> {
    * @param cql the query to convert
    * @return {@link CriteriaQuery} for selection
    */
-  public CriteriaQuery<E> toCollectCriteria(String cql) {
+  public CriteriaQuery<E> toCollectCriteria(String cql, boolean ignoreCase) {
     try {
       var node = new CQLParser().parse(cql);
 
       var cb = em.getCriteriaBuilder();
       var query = cb.createQuery(domainClass);
       var root = query.from(domainClass);
-      var predicate = createPredicate(node, root, cb, query);
+      var predicate = createPredicate(node, root, cb, query, ignoreCase);
 
       query.where(predicate);
       return query;
@@ -106,7 +106,7 @@ public class Cql2JpaCriteria<E> {
    * @param cql the query to convert
    * @return {@link CriteriaQuery} for count
    */
-  public CriteriaQuery<Long> toCountCriteria(String cql) {
+  public CriteriaQuery<Long> toCountCriteria(String cql, boolean ignoreCase) {
     try {
       var node = new CQLParser().parse(cql);
 
@@ -114,7 +114,8 @@ public class Cql2JpaCriteria<E> {
       var query = cb.createQuery(Long.class);
       var root = query.from(domainClass);
       query.select(cb.count(root));
-      var predicate = createPredicate(node, root, cb, query);
+      //FIXME
+      var predicate = createPredicate(node, root, cb, query, ignoreCase);
       query.orderBy(Collections.emptyList());
       root.getFetches().clear();
       query.where(predicate);
@@ -152,7 +153,7 @@ public class Cql2JpaCriteria<E> {
     return (root, query, criteriaBuilder) -> {
       try {
         var node = new CQLParser().parse(cql);
-        return createPredicate(node, root, criteriaBuilder, query);
+        return createPredicate(node, root, criteriaBuilder, query, false);
       } catch (IOException | CQLParseException | QueryValidationException e) {
         throw new CqlQueryValidationException(e);
       }
@@ -170,22 +171,24 @@ public class Cql2JpaCriteria<E> {
     return (root, query, criteriaBuilder) -> {
       try {
         var node = new CQLParser().parse(cql);
-        return createPredicate(node, root, criteriaBuilder, criteriaBuilder.createQuery(Long.class));
+        //FIXME
+        return createPredicate(node, root, criteriaBuilder, criteriaBuilder.createQuery(Long.class), false);
       } catch (IOException | CQLParseException | QueryValidationException e) {
         throw new CqlQueryValidationException(e);
       }
     };
   }
 
-  private <T> Predicate createPredicate(CQLNode node, Root<E> root, CriteriaBuilder cb, CriteriaQuery<T> query)
+  private <T> Predicate createPredicate(CQLNode node, Root<E> root, CriteriaBuilder cb,
+    CriteriaQuery<T> query, boolean ignoreCase)
     throws QueryValidationException {
     Predicate predicates;
     if (node instanceof CQLSortNode sortNode) {
       var orders = toOrders(sortNode, root, cb);
       query.orderBy(orders);
-      predicates = process(sortNode.getSubtree(), cb, root, query);
+      predicates = process(sortNode.getSubtree(), cb, root, query, ignoreCase);
     } else {
-      predicates = process(node, cb, root, query);
+      predicates = process(node, cb, root, query, ignoreCase);
     }
     return predicates;
   }
@@ -204,10 +207,10 @@ public class Cql2JpaCriteria<E> {
     return orders;
   }
 
-  private Predicate process(CQLNode node, CriteriaBuilder cb, Root<E> root, CriteriaQuery<?> query)
-    throws QueryValidationException {
+  private Predicate process(CQLNode node, CriteriaBuilder cb, Root<E> root, CriteriaQuery<?> query,
+    boolean ignoreCase) throws QueryValidationException {
     if (node instanceof CQLTermNode cqlTermNode) {
-      return processTerm(cqlTermNode, cb, root, query);
+      return processTerm(cqlTermNode, cb, root, query, ignoreCase);
     } else if (node instanceof CQLBooleanNode cqlBooleanNode) {
       return processBoolean(cqlBooleanNode, cb, root, query);
     } else {
@@ -218,7 +221,7 @@ public class Cql2JpaCriteria<E> {
   private Predicate processBoolean(CQLBooleanNode node, CriteriaBuilder cb, Root<E> root, CriteriaQuery<?> query)
     throws QueryValidationException {
     if (node instanceof CQLAndNode) {
-      return cb.and(process(node.getLeftOperand(), cb, root, query), process(node.getRightOperand(), cb, root, query));
+      return cb.and(process(node.getLeftOperand(), cb, root, query, false), process(node.getRightOperand(), cb, root, query, false));
     } else if (node instanceof CQLOrNode) {
       if (node.getRightOperand().getClass() == CQLTermNode.class) {
         // special case for the query the UI uses most often, before the user has
@@ -227,21 +230,21 @@ public class Cql2JpaCriteria<E> {
         if (ASTERISKS_SIGN.equals(rightOperand.getTerm()) && "=".equals(rightOperand.getRelation().getBase())
           && isEmpty(rightOperand.getRelation().getModifiers())) {
           log.debug("pgFT(): Simplifying =* OR =* ");
-          return process(node.getLeftOperand(), cb, root, query);
+          return process(node.getLeftOperand(), cb, root, query, false);
         }
       }
-      return cb.or(process(node.getLeftOperand(), cb, root, query), process(node.getRightOperand(), cb, root, query));
+      return cb.or(process(node.getLeftOperand(), cb, root, query, false), process(node.getRightOperand(), cb, root, query, false));
     } else if (node instanceof CQLNotNode) {
       return
-        cb.and(process(node.getLeftOperand(), cb, root, query),
-          cb.not(process(node.getRightOperand(), cb, root, query)));
+        cb.and(process(node.getLeftOperand(), cb, root, query, false),
+          cb.not(process(node.getRightOperand(), cb, root, query, false)));
     } else {
       throw createUnsupportedException(node);
     }
   }
 
-  private Predicate processTerm(CQLTermNode node, CriteriaBuilder cb, Root<E> root, CriteriaQuery<?> query)
-    throws QueryValidationException {
+  private Predicate processTerm(CQLTermNode node, CriteriaBuilder cb, Root<E> root,
+    CriteriaQuery<?> query, boolean ignoreCase) throws QueryValidationException {
     var fieldName = node.getIndex();
     if (StringUtils.startsWithIgnoreCase(fieldName, "cql")) {
       if ("cql.allRecords".equalsIgnoreCase(fieldName)) {
@@ -256,7 +259,7 @@ public class Cql2JpaCriteria<E> {
     if (!isEmpty(cqlModifiers.getRelationModifiers())) {
       query.distinct(true);
     }
-    return indexNode(field, node, cqlModifiers, cb);
+    return indexNode(field, node, cqlModifiers, cb, ignoreCase);
   }
 
   private Path<?> getPath(CQLTermNode node, Root<E> root) {
@@ -274,14 +277,18 @@ public class Cql2JpaCriteria<E> {
   }
 
   private static <G extends Comparable<? super G>> Predicate toPredicate(Expression<G> field, G value,
-    String comparator, CriteriaBuilder cb) throws QueryValidationException {
+    String comparator, CriteriaBuilder cb, boolean ignoreCase) throws QueryValidationException {
     return switch (comparator) {
       case ">" -> cb.greaterThan(field, value);
       case "<" -> cb.lessThan(field, value);
       case ">=" -> cb.greaterThanOrEqualTo(field, value);
       case "<=" -> cb.lessThanOrEqualTo(field, value);
-      case "==", "=" -> cb.equal(field, value);
-      case NOT_EQUALS_OPERATOR -> cb.notEqual(field, value);
+      case "==", "=" -> ignoreCase && field.getJavaType().equals(String.class)
+        ? cb.equal(cb.lower(field.as(String.class)), value.toString().toLowerCase())
+        : cb.equal(field, value);
+      case NOT_EQUALS_OPERATOR -> ignoreCase && field.getJavaType().equals(String.class)
+        ? cb.notEqual(cb.lower(field.as(String.class)), value.toString().toLowerCase())
+        : cb.notEqual(field, value);
       default -> throw new QueryValidationException(
         "CQL: Unsupported operator '"
           + comparator
@@ -291,9 +298,7 @@ public class Cql2JpaCriteria<E> {
   }
 
   private Predicate indexNode(Path<?> field, CQLTermNode node, CqlModifiers modifiers,
-                              CriteriaBuilder cb)
-    throws QueryValidationException {
-
+                              CriteriaBuilder cb, boolean ignoreCase) throws QueryValidationException {
     if (!isEmpty(modifiers.getRelationModifiers())) {
       return buildModifiersQuery(field, modifiers, cb);
     }
@@ -307,10 +312,10 @@ public class Cql2JpaCriteria<E> {
 
     return switch (comparator) {
       case "=" -> modifiers.getCqlTermFormat() == NUMBER
-        ? queryBySql(field, term, comparator, cb)
-        : buildQuery(field, term, comparator, cb);
-      case "adj", "all", "any", "==", NOT_EQUALS_OPERATOR -> buildQuery(field, term, comparator, cb);
-      case "<", ">", "<=", ">=" -> queryBySql(field, node.getTerm(), comparator, cb);
+        ? queryBySql(field, term, comparator, cb, ignoreCase)
+        : buildQuery(field, term, comparator, cb, ignoreCase);
+      case "adj", "all", "any", "==", NOT_EQUALS_OPERATOR -> buildQuery(field, term, comparator, cb, ignoreCase);
+      case "<", ">", "<=", ">=" -> queryBySql(field, node.getTerm(), comparator, cb, ignoreCase);
       default -> throw new CQLFeatureUnsupportedException("Relation " + comparator + " not implemented yet: " + node);
     };
   }
@@ -326,12 +331,12 @@ public class Cql2JpaCriteria<E> {
 
   @SuppressWarnings({"rawtypes", "unchecked"})
   private Predicate buildQuery(Path<?> field, Comparable term, String comparator,
-                               CriteriaBuilder cb) throws QueryValidationException {
+                               CriteriaBuilder cb, boolean ignoreCase) throws QueryValidationException {
     boolean isString = String.class.equals(field.getJavaType());
     if (isString) {
-      return queryByLike((Path<String>) field, (String) term, comparator, cb);
+      return queryByLike((Path<String>) field, (String) term, comparator, cb, ignoreCase);
     } else {
-      return queryBySql(field, term, comparator, cb);
+      return queryBySql(field, term, comparator, cb, ignoreCase);
     }
   }
 
@@ -343,7 +348,8 @@ public class Cql2JpaCriteria<E> {
       var fieldName = getFieldNameByModifier(field, modifier);
       var fieldValue = modifier.getValue();
 
-      result = cb.and(result, queryBySql(field.get(fieldName), fieldValue, modifier.getComparison(), cb));
+      //FIXME
+      result = cb.and(result, queryBySql(field.get(fieldName), fieldValue, modifier.getComparison(), cb, false));
     }
 
     return result;
@@ -365,11 +371,15 @@ public class Cql2JpaCriteria<E> {
    * Create an SQL expression using LIKE query syntax.
    */
   private static Predicate queryByLike(Path<String> field, String term, String comparator,
-                                CriteriaBuilder cb) {
+                                CriteriaBuilder cb, boolean ignoreCase) {
     if (NOT_EQUALS_OPERATOR.equals(comparator)) {
-      return cb.notLike(field, cql2like(term), '\\');
+      return ignoreCase
+      ? cb.notLike(cb.lower(field), cql2like(term).toLowerCase())
+      : cb.notLike(field, cql2like(term), '\\');
     } else {
-      return cb.like(field, cql2like(term), '\\');
+      return ignoreCase
+        ? cb.like(cb.lower(field), cql2like(term).toLowerCase())
+        : cb.like(field, cql2like(term), '\\');
     }
   }
 
@@ -385,7 +395,7 @@ public class Cql2JpaCriteria<E> {
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
   private static Predicate queryBySql(Expression field, Comparable term, String comparator,
-                                      CriteriaBuilder cb) throws QueryValidationException {
+                                      CriteriaBuilder cb, boolean ignoreCase) throws QueryValidationException {
     var value = (String) term;
 
     var javaType = field.getJavaType();
@@ -412,7 +422,7 @@ public class Cql2JpaCriteria<E> {
       field = field.as(String.class);
     }
 
-    return toPredicate(field, term, comparator, cb);
+    return toPredicate(field, term, comparator, cb, ignoreCase);
   }
 
   private static CQLFeatureUnsupportedException createUnsupportedException(CQLNode node) {

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
@@ -219,7 +219,8 @@ public class Cql2JpaCriteria<E> {
   private Predicate processBoolean(CQLBooleanNode node, CriteriaBuilder cb, Root<E> root, CriteriaQuery<?> query)
     throws QueryValidationException {
     if (node instanceof CQLAndNode) {
-      return cb.and(process(node.getLeftOperand(), cb, root, query, false), process(node.getRightOperand(), cb, root, query, false));
+      return cb.and(process(node.getLeftOperand(), cb, root, query, false),
+        process(node.getRightOperand(), cb, root, query, false));
     } else if (node instanceof CQLOrNode) {
       if (node.getRightOperand().getClass() == CQLTermNode.class) {
         // special case for the query the UI uses most often, before the user has
@@ -231,7 +232,8 @@ public class Cql2JpaCriteria<E> {
           return process(node.getLeftOperand(), cb, root, query, false);
         }
       }
-      return cb.or(process(node.getLeftOperand(), cb, root, query, false), process(node.getRightOperand(), cb, root, query, false));
+      return cb.or(process(node.getLeftOperand(), cb, root, query, false),
+        process(node.getRightOperand(), cb, root, query, false));
     } else if (node instanceof CQLNotNode) {
       return
         cb.and(process(node.getLeftOperand(), cb, root, query, false),
@@ -371,8 +373,8 @@ public class Cql2JpaCriteria<E> {
                                 CriteriaBuilder cb, boolean ignoreCase) {
     if (NOT_EQUALS_OPERATOR.equals(comparator)) {
       return ignoreCase
-      ? cb.notLike(cb.lower(field), cql2like(term).toLowerCase())
-      : cb.notLike(field, cql2like(term), '\\');
+        ? cb.notLike(cb.lower(field), cql2like(term).toLowerCase())
+        : cb.notLike(field, cql2like(term), '\\');
     } else {
       return ignoreCase
         ? cb.like(cb.lower(field), cql2like(term).toLowerCase())

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
@@ -114,7 +114,6 @@ public class Cql2JpaCriteria<E> {
       var query = cb.createQuery(Long.class);
       var root = query.from(domainClass);
       query.select(cb.count(root));
-      //FIXME
       var predicate = createPredicate(node, root, cb, query, ignoreCase);
       query.orderBy(Collections.emptyList());
       root.getFetches().clear();
@@ -171,7 +170,6 @@ public class Cql2JpaCriteria<E> {
     return (root, query, criteriaBuilder) -> {
       try {
         var node = new CQLParser().parse(cql);
-        //FIXME
         return createPredicate(node, root, criteriaBuilder, criteriaBuilder.createQuery(Long.class), false);
       } catch (IOException | CQLParseException | QueryValidationException e) {
         throw new CqlQueryValidationException(e);
@@ -348,7 +346,6 @@ public class Cql2JpaCriteria<E> {
       var fieldName = getFieldNameByModifier(field, modifier);
       var fieldValue = modifier.getValue();
 
-      //FIXME
       result = cb.and(result, queryBySql(field.get(fieldName), fieldValue, modifier.getComparison(), cb, false));
     }
 

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/IgnoreAccents.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/IgnoreAccents.java
@@ -1,0 +1,22 @@
+package org.folio.spring.cql;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Ignore accents when comparing strings.
+ * This is the default but might be used to make it explicit.
+ * String are considered equal if they are the same after removing accents.
+ *
+ * @see RespectAccents
+ * @see IgnoreCase
+ * @see RespectCase
+ */
+@Documented
+@Target({TYPE})
+@Retention(RUNTIME)
+public @interface IgnoreAccents {}

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/IgnoreCase.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/IgnoreCase.java
@@ -1,0 +1,21 @@
+package org.folio.spring.cql;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Use case insensitive matching when comparing strings.
+ * This is the default but might be used to make it explicit.
+ *
+ * @see RespectCase
+ * @see RespectAccents
+ * @see IgnoreAccents
+ */
+@Documented
+@Target({TYPE})
+@Retention(RUNTIME)
+public @interface IgnoreCase {}

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepository.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepository.java
@@ -10,9 +10,5 @@ public interface JpaCqlRepository<T, I> extends JpaRepository<T, I> {
 
   Page<T> findByCql(String cql, Pageable pageable);
 
-  Page<T> findByCqlIgnoreCase(String cql, Pageable pageable);
-
   long count(String cql);
-
-  long countIgnoreCase(String cql);
 }

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepository.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepository.java
@@ -10,5 +10,8 @@ public interface JpaCqlRepository<T, I> extends JpaRepository<T, I> {
 
   Page<T> findByCql(String cql, Pageable pageable);
 
+  Page<T> findByCqlIgnoreCase(String cql, Pageable pageable, boolean ignoreCase);
+
   long count(String cql);
+  long countIgnoreCase(String cql, boolean ignoreCase);
 }

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepository.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepository.java
@@ -10,9 +10,9 @@ public interface JpaCqlRepository<T, I> extends JpaRepository<T, I> {
 
   Page<T> findByCql(String cql, Pageable pageable);
 
-  Page<T> findByCqlIgnoreCase(String cql, Pageable pageable, boolean ignoreCase);
+  Page<T> findByCqlIgnoreCase(String cql, Pageable pageable);
 
   long count(String cql);
 
-  long countIgnoreCase(String cql, boolean ignoreCase);
+  long countIgnoreCase(String cql);
 }

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepository.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepository.java
@@ -13,5 +13,6 @@ public interface JpaCqlRepository<T, I> extends JpaRepository<T, I> {
   Page<T> findByCqlIgnoreCase(String cql, Pageable pageable, boolean ignoreCase);
 
   long count(String cql);
+
   long countIgnoreCase(String cql, boolean ignoreCase);
 }

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepositoryImpl.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepositoryImpl.java
@@ -45,14 +45,14 @@ public class JpaCqlRepositoryImpl<T, I> extends SimpleJpaRepository<T, I> implem
   }
 
   @Override
-  public Page<T> findByCqlIgnoreCase(String cql, Pageable pageable, boolean ignoreCase) {
-    var criteria = cql2JpaCriteria.toCollectCriteria(cql, ignoreCase);
+  public Page<T> findByCqlIgnoreCase(String cql, Pageable pageable) {
+    var criteria = cql2JpaCriteria.toCollectCriteria(cql, true);
     List<T> resultList = em
       .createQuery(criteria)
       .setFirstResult((int) pageable.getOffset())
       .setMaxResults(pageable.getPageSize())
       .getResultList();
-    return PageableExecutionUtils.getPage(resultList, pageable, () -> countIgnoreCase(cql, true));
+    return PageableExecutionUtils.getPage(resultList, pageable, () -> countIgnoreCase(cql));
   }
 
   @Override
@@ -62,8 +62,8 @@ public class JpaCqlRepositoryImpl<T, I> extends SimpleJpaRepository<T, I> implem
   }
 
   @Override
-  public long countIgnoreCase(String cql, boolean ignoreCase) {
-    var criteria = cql2JpaCriteria.toCountCriteria(cql, ignoreCase);
+  public long countIgnoreCase(String cql) {
+    var criteria = cql2JpaCriteria.toCountCriteria(cql, true);
     return em.createQuery(criteria).getSingleResult();
   }
 }

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepositoryImpl.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepositoryImpl.java
@@ -35,7 +35,7 @@ public class JpaCqlRepositoryImpl<T, I> extends SimpleJpaRepository<T, I> implem
 
   @Override
   public Page<T> findByCql(String cql, Pageable pageable) {
-    var criteria = cql2JpaCriteria.toCollectCriteria(cql, false);
+    var criteria = cql2JpaCriteria.toCollectCriteria(cql);
     List<T> resultList = em
       .createQuery(criteria)
       .setFirstResult((int) pageable.getOffset())
@@ -45,25 +45,9 @@ public class JpaCqlRepositoryImpl<T, I> extends SimpleJpaRepository<T, I> implem
   }
 
   @Override
-  public Page<T> findByCqlIgnoreCase(String cql, Pageable pageable) {
-    var criteria = cql2JpaCriteria.toCollectCriteria(cql, true);
-    List<T> resultList = em
-      .createQuery(criteria)
-      .setFirstResult((int) pageable.getOffset())
-      .setMaxResults(pageable.getPageSize())
-      .getResultList();
-    return PageableExecutionUtils.getPage(resultList, pageable, () -> countIgnoreCase(cql));
-  }
-
-  @Override
   public long count(String cql) {
-    var criteria = cql2JpaCriteria.toCountCriteria(cql, false);
+    var criteria = cql2JpaCriteria.toCountCriteria(cql);
     return em.createQuery(criteria).getSingleResult();
   }
 
-  @Override
-  public long countIgnoreCase(String cql) {
-    var criteria = cql2JpaCriteria.toCountCriteria(cql, true);
-    return em.createQuery(criteria).getSingleResult();
-  }
 }

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepositoryImpl.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlRepositoryImpl.java
@@ -35,7 +35,7 @@ public class JpaCqlRepositoryImpl<T, I> extends SimpleJpaRepository<T, I> implem
 
   @Override
   public Page<T> findByCql(String cql, Pageable pageable) {
-    var criteria = cql2JpaCriteria.toCollectCriteria(cql);
+    var criteria = cql2JpaCriteria.toCollectCriteria(cql, false);
     List<T> resultList = em
       .createQuery(criteria)
       .setFirstResult((int) pageable.getOffset())
@@ -45,9 +45,25 @@ public class JpaCqlRepositoryImpl<T, I> extends SimpleJpaRepository<T, I> implem
   }
 
   @Override
+  public Page<T> findByCqlIgnoreCase(String cql, Pageable pageable, boolean ignoreCase) {
+    var criteria = cql2JpaCriteria.toCollectCriteria(cql, ignoreCase);
+    List<T> resultList = em
+      .createQuery(criteria)
+      .setFirstResult((int) pageable.getOffset())
+      .setMaxResults(pageable.getPageSize())
+      .getResultList();
+    return PageableExecutionUtils.getPage(resultList, pageable, () -> countIgnoreCase(cql, true));
+  }
+
+  @Override
   public long count(String cql) {
-    var criteria = cql2JpaCriteria.toCountCriteria(cql);
+    var criteria = cql2JpaCriteria.toCountCriteria(cql, false);
     return em.createQuery(criteria).getSingleResult();
   }
 
+  @Override
+  public long countIgnoreCase(String cql, boolean ignoreCase) {
+    var criteria = cql2JpaCriteria.toCountCriteria(cql, ignoreCase);
+    return em.createQuery(criteria).getSingleResult();
+  }
 }

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/RespectAccents.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/RespectAccents.java
@@ -1,0 +1,21 @@
+package org.folio.spring.cql;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Respect accents when comparing strings.
+ * String are considered equal if they are the same after removing accents.
+ *
+ * @see IgnoreAccents
+ * @see RespectCase
+ * @see IgnoreCase
+ */
+@Documented
+@Target({TYPE})
+@Retention(RUNTIME)
+public @interface RespectAccents {}

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/RespectCase.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/RespectCase.java
@@ -1,0 +1,20 @@
+package org.folio.spring.cql;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Use case sensitive matching when comparing strings.
+ *
+ * @see IgnoreCase
+ * @see RespectAccents
+ * @see IgnoreAccents
+ */
+@Documented
+@Target({TYPE})
+@Retention(RUNTIME)
+public @interface RespectCase {}

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlModifiersIT.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlModifiersIT.java
@@ -20,7 +20,8 @@ import org.springframework.test.context.jdbc.Sql;
 @EnablePostgres
 @ContextConfiguration(classes = JpaCqlConfiguration.class)
 @EnableAutoConfiguration(exclude = FlywayAutoConfiguration.class)
-@Sql({"/sql/jpa-cql-modifiers-it-schema.sql", "/sql/jpa-cql-modifiers-test-data.sql"})
+@Sql({"/sql/jpa-cql-general-it-schema.sql",
+      "/sql/jpa-cql-modifiers-it-schema.sql", "/sql/jpa-cql-modifiers-test-data.sql"})
 class JpaCqlModifiersIT {
 
   @Autowired

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
@@ -10,9 +10,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.folio.spring.cql.domain.City;
+import org.folio.spring.cql.domain.Language;
 import org.folio.spring.cql.domain.Person;
 import org.folio.spring.cql.domain.Str;
 import org.folio.spring.cql.repo.CityRepository;
+import org.folio.spring.cql.repo.LanguageRepository;
 import org.folio.spring.cql.repo.PersonRepository;
 import org.folio.spring.cql.repo.StrRepository;
 import org.folio.spring.testing.extension.EnablePostgres;
@@ -48,6 +50,9 @@ class JpaCqlRepositoryIT {
   @Autowired
   private StrRepository strRepository;
 
+  @Autowired
+  private LanguageRepository languageRepository;
+
   @Test
   void testTypesOfRepositories() {
     assertThat(personRepository).isInstanceOf(JpaCqlRepository.class);
@@ -63,6 +68,24 @@ class JpaCqlRepositoryIT {
       .extracting(Person::getAge)
       .startsWith(20)
       .endsWith(40);
+  }
+
+  @Test
+  @Sql({
+    "/sql/jpa-cql-lang-ignore-case-test-data.sql"
+  })
+  void testFindByCqlIgnoreCase() {
+    var page = languageRepository.findByCqlIgnoreCase("name=Java",
+      PageRequest.of(0, 10), true);
+
+    assertThat(page)
+      .extracting(Language::getName)
+      .contains("Java", "jAva", "JaVa", "javA")
+      .hasSize(4);
+
+    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
+      true))
+      .isEqualTo(4);
   }
 
   @Test

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
@@ -74,7 +74,7 @@ class JpaCqlRepositoryIT {
   @Sql({
     "/sql/jpa-cql-lang-ignore-case-test-data.sql"
   })
-  void testFindByCqlIgnoreCase() {
+  void testFindByCqlIgnoreCaseWhenTrue() {
     var page = languageRepository.findByCqlIgnoreCase("name=Java",
       PageRequest.of(0, 10), true);
 
@@ -92,16 +92,17 @@ class JpaCqlRepositoryIT {
   @Sql({
     "/sql/jpa-cql-lang-ignore-case-test-data.sql"
   })
-  void testFindByCql() {
-    var page = languageRepository.findByCql("name=Java",
-      PageRequest.of(0, 10));
+  void testFindByCqlIgnoreCaseWhenFalse() {
+    var page = languageRepository.findByCqlIgnoreCase("name=Java",
+      PageRequest.of(0, 10), false);
 
     assertThat(page)
       .extracting(Language::getName)
       .contains("Java")
       .hasSize(1);
 
-    assertThat(languageRepository.count("(cql.allRecords=1)sortby name/sort.ascending"))
+    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
+      false))
       .isEqualTo(4);
   }
 

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
@@ -1,14 +1,20 @@
 package org.folio.spring.cql;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Expression;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.folio.cql2pgjson.exception.QueryValidationException;
 import org.folio.spring.cql.domain.City;
 import org.folio.spring.cql.domain.Language;
 import org.folio.spring.cql.domain.LanguageRespectAccents;
@@ -380,21 +386,28 @@ class JpaCqlRepositoryIT {
     );
   }
 
-  @Test
-  void testUnsupportedFeatureQuery() {
-    org.junit.jupiter.api.Assertions.assertThrows(CqlQueryValidationException.class,
-      () -> personRepository.count("name prox Jon")
-    );
+  @ParameterizedTest
+  @CsvSource(textBlock = """
+      name prox Jon,   CQLProxNode
+      city.name%Kyiv,  CQLTermNode
+      age within 0 18, Relation within not implemented
+      """)
+  void testFindByCqlThrowsCqlQueryValidationException(String cql, String message) {
+    var offsetRequest = PageRequest.of(0, 10);
+    assertThatThrownBy(() -> personRepository.findByCql(cql, offsetRequest))
+      .isInstanceOf(CqlQueryValidationException.class)
+      .hasMessageContaining(message);
   }
 
-  @Test
-  void testWithUnsupportedQueryOperator() {
-    var offsetRequest = PageRequest.of(0, 10);
-    var thrown = org.junit.jupiter.api.Assertions.assertThrows(CqlQueryValidationException.class,
-      () -> personRepository.findByCql("city.name%Kyiv", offsetRequest)
-    );
-
-    org.junit.jupiter.api.Assertions.assertTrue(thrown.getMessage().contains("Not implemented yet"));
+  @ParameterizedTest
+  @ValueSource(classes = { String.class, Integer.class })
+  void testQueryByCqlThrowsUnsupportedOperatorException(Class<?> theClass) {
+    var cql2JpaCriteria = new Cql2JpaCriteria<>(LanguageRespectCaseRespectAccents.class, null);
+    Expression<String> expression = when(mock(Expression.class).getJavaType()).thenReturn(theClass).getMock();
+    var cb = mock(CriteriaBuilder.class);
+    assertThatThrownBy(() -> cql2JpaCriteria.queryBySql(expression, "term", "~", cb))
+      .isInstanceOf(QueryValidationException.class)
+      .hasMessageContaining("Unsupported operator '~'");
   }
 
   @Test

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
@@ -74,7 +74,7 @@ class JpaCqlRepositoryIT {
   @Sql({
     "/sql/jpa-cql-lang-ignore-case-test-data.sql"
   })
-  void testFindByCqlIgnoreCaseWhenTrue() {
+  void testFindByCqlIgnoreCaseWhenTrueEqualOperator() {
     var page = languageRepository.findByCqlIgnoreCase("name=Java",
       PageRequest.of(0, 10), true);
 
@@ -85,14 +85,50 @@ class JpaCqlRepositoryIT {
 
     assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
       true))
-      .isEqualTo(4);
+      .isEqualTo(5);
   }
 
   @Test
   @Sql({
     "/sql/jpa-cql-lang-ignore-case-test-data.sql"
   })
-  void testFindByCqlIgnoreCaseWhenFalse() {
+  void testFindByCqlIgnoreCaseWhenTrueDoubleEqualOperator() {
+    var page = languageRepository.findByCqlIgnoreCase("name==Java",
+      PageRequest.of(0, 10), true);
+
+    assertThat(page)
+      .extracting(Language::getName)
+      .contains("Java", "jAva", "JaVa", "javA")
+      .hasSize(4);
+
+    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
+      true))
+      .isEqualTo(5);
+  }
+
+  @Test
+  @Sql({
+    "/sql/jpa-cql-lang-ignore-case-test-data.sql"
+  })
+  void testFindByCqlIgnoreCaseTrueWhenNotEqualOperator() {
+    var page = languageRepository.findByCqlIgnoreCase("name<>Java",
+      PageRequest.of(0, 10), true);
+
+    assertThat(page)
+      .extracting(Language::getName)
+      .contains("python")
+      .hasSize(1);
+
+    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
+      true))
+      .isEqualTo(5);
+  }
+
+  @Test
+  @Sql({
+    "/sql/jpa-cql-lang-ignore-case-test-data.sql"
+  })
+  void testFindByCqlIgnoreCaseFalseWhenEqualOperator() {
     var page = languageRepository.findByCqlIgnoreCase("name=Java",
       PageRequest.of(0, 10), false);
 
@@ -103,7 +139,43 @@ class JpaCqlRepositoryIT {
 
     assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
       false))
-      .isEqualTo(4);
+      .isEqualTo(5);
+  }
+
+  @Test
+  @Sql({
+    "/sql/jpa-cql-lang-ignore-case-test-data.sql"
+  })
+  void testFindByCqlIgnoreCaseFalseWhenDoubleEqualOperator() {
+    var page = languageRepository.findByCqlIgnoreCase("name==Java",
+      PageRequest.of(0, 10), false);
+
+    assertThat(page)
+      .extracting(Language::getName)
+      .contains("Java")
+      .hasSize(1);
+
+    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
+      false))
+      .isEqualTo(5);
+  }
+
+  @Test
+  @Sql({
+    "/sql/jpa-cql-lang-ignore-case-test-data.sql"
+  })
+  void testFindByCqlIgnoreCaseFalseWhenNotEqualOperator() {
+    var page = languageRepository.findByCqlIgnoreCase("name<>Java",
+      PageRequest.of(0, 10), false);
+
+    assertThat(page)
+      .extracting(Language::getName)
+      .contains("python", "jAva", "JaVa", "javA")
+      .hasSize(4);
+
+    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
+      false))
+      .isEqualTo(5);
   }
 
   @Test

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
@@ -76,15 +76,14 @@ class JpaCqlRepositoryIT {
   })
   void testFindByCqlIgnoreCaseWhenTrueEqualOperator() {
     var page = languageRepository.findByCqlIgnoreCase("name=Java",
-      PageRequest.of(0, 10), true);
+      PageRequest.of(0, 10));
 
     assertThat(page)
       .extracting(Language::getName)
       .contains("Java", "jAva", "JaVa", "javA")
       .hasSize(4);
 
-    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
-      true))
+    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending"))
       .isEqualTo(5);
   }
 
@@ -92,17 +91,16 @@ class JpaCqlRepositoryIT {
   @Sql({
     "/sql/jpa-cql-lang-ignore-case-test-data.sql"
   })
-  void testFindByCqlIgnoreCaseWhenTrueDoubleEqualOperator() {
+  void testFindByCqlIgnoreCaseWhenDoubleEqualOperator() {
     var page = languageRepository.findByCqlIgnoreCase("name==Java",
-      PageRequest.of(0, 10), true);
+      PageRequest.of(0, 10));
 
     assertThat(page)
       .extracting(Language::getName)
       .contains("Java", "jAva", "JaVa", "javA")
       .hasSize(4);
 
-    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
-      true))
+    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending"))
       .isEqualTo(5);
   }
 
@@ -110,71 +108,16 @@ class JpaCqlRepositoryIT {
   @Sql({
     "/sql/jpa-cql-lang-ignore-case-test-data.sql"
   })
-  void testFindByCqlIgnoreCaseTrueWhenNotEqualOperator() {
+  void testFindByCqlIgnoreCaseWhenNotEqualOperator() {
     var page = languageRepository.findByCqlIgnoreCase("name<>Java",
-      PageRequest.of(0, 10), true);
+      PageRequest.of(0, 10));
 
     assertThat(page)
       .extracting(Language::getName)
       .contains("python")
       .hasSize(1);
 
-    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
-      true))
-      .isEqualTo(5);
-  }
-
-  @Test
-  @Sql({
-    "/sql/jpa-cql-lang-ignore-case-test-data.sql"
-  })
-  void testFindByCqlIgnoreCaseFalseWhenEqualOperator() {
-    var page = languageRepository.findByCqlIgnoreCase("name=Java",
-      PageRequest.of(0, 10), false);
-
-    assertThat(page)
-      .extracting(Language::getName)
-      .contains("Java")
-      .hasSize(1);
-
-    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
-      false))
-      .isEqualTo(5);
-  }
-
-  @Test
-  @Sql({
-    "/sql/jpa-cql-lang-ignore-case-test-data.sql"
-  })
-  void testFindByCqlIgnoreCaseFalseWhenDoubleEqualOperator() {
-    var page = languageRepository.findByCqlIgnoreCase("name==Java",
-      PageRequest.of(0, 10), false);
-
-    assertThat(page)
-      .extracting(Language::getName)
-      .contains("Java")
-      .hasSize(1);
-
-    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
-      false))
-      .isEqualTo(5);
-  }
-
-  @Test
-  @Sql({
-    "/sql/jpa-cql-lang-ignore-case-test-data.sql"
-  })
-  void testFindByCqlIgnoreCaseFalseWhenNotEqualOperator() {
-    var page = languageRepository.findByCqlIgnoreCase("name<>Java",
-      PageRequest.of(0, 10), false);
-
-    assertThat(page)
-      .extracting(Language::getName)
-      .contains("python", "jAva", "JaVa", "javA")
-      .hasSize(4);
-
-    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending",
-      false))
+    assertThat(languageRepository.countIgnoreCase("(cql.allRecords=1)sortby name/sort.ascending"))
       .isEqualTo(5);
   }
 

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/JpaCqlRepositoryIT.java
@@ -90,6 +90,23 @@ class JpaCqlRepositoryIT {
 
   @Test
   @Sql({
+    "/sql/jpa-cql-lang-ignore-case-test-data.sql"
+  })
+  void testFindByCql() {
+    var page = languageRepository.findByCql("name=Java",
+      PageRequest.of(0, 10));
+
+    assertThat(page)
+      .extracting(Language::getName)
+      .contains("Java")
+      .hasSize(1);
+
+    assertThat(languageRepository.count("(cql.allRecords=1)sortby name/sort.ascending"))
+      .isEqualTo(4);
+  }
+
+  @Test
+  @Sql({
     "/sql/jpa-cql-person-test-data.sql"
   })
   void testSelectsWithAndWithoutDeletedCriteria() {

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/domain/Language.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/domain/Language.java
@@ -1,0 +1,18 @@
+package org.folio.spring.cql.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+
+@Entity
+@Data
+@Table(name = "lang")
+public class Language {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private int id;
+  private String name;
+}

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/domain/LanguageRespectAccents.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/domain/LanguageRespectAccents.java
@@ -1,0 +1,20 @@
+package org.folio.spring.cql.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+import org.folio.spring.cql.RespectAccents;
+
+@Entity
+@Data
+@Table(name = "lang")
+@RespectAccents
+public class LanguageRespectAccents {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private int id;
+  private String name;
+}

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/domain/LanguageRespectCase.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/domain/LanguageRespectCase.java
@@ -1,0 +1,20 @@
+package org.folio.spring.cql.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+import org.folio.spring.cql.RespectCase;
+
+@Entity
+@Data
+@Table(name = "lang")
+@RespectCase
+public class LanguageRespectCase {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private int id;
+  private String name;
+}

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/domain/LanguageRespectCaseRespectAccents.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/domain/LanguageRespectCaseRespectAccents.java
@@ -1,0 +1,22 @@
+package org.folio.spring.cql.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
+import org.folio.spring.cql.RespectAccents;
+import org.folio.spring.cql.RespectCase;
+
+@Entity
+@Data
+@Table(name = "lang")
+@RespectCase
+@RespectAccents
+public class LanguageRespectCaseRespectAccents {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private int id;
+  private String name;
+}

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/LanguageRepository.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/LanguageRepository.java
@@ -1,0 +1,7 @@
+package org.folio.spring.cql.repo;
+
+import org.folio.spring.cql.JpaCqlRepository;
+import org.folio.spring.cql.domain.Language;
+
+public interface LanguageRepository extends JpaCqlRepository<Language, Integer> {
+}

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/LanguageRespectAccentsRepository.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/LanguageRespectAccentsRepository.java
@@ -1,0 +1,7 @@
+package org.folio.spring.cql.repo;
+
+import org.folio.spring.cql.JpaCqlRepository;
+import org.folio.spring.cql.domain.LanguageRespectAccents;
+
+public interface LanguageRespectAccentsRepository extends JpaCqlRepository<LanguageRespectAccents, Integer> {
+}

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/LanguageRespectCaseRepository.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/LanguageRespectCaseRepository.java
@@ -1,0 +1,7 @@
+package org.folio.spring.cql.repo;
+
+import org.folio.spring.cql.JpaCqlRepository;
+import org.folio.spring.cql.domain.LanguageRespectCase;
+
+public interface LanguageRespectCaseRepository extends JpaCqlRepository<LanguageRespectCase, Integer> {
+}

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/LanguageRespectCaseRespectAccentsRepository.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/repo/LanguageRespectCaseRespectAccentsRepository.java
@@ -1,0 +1,8 @@
+package org.folio.spring.cql.repo;
+
+import org.folio.spring.cql.JpaCqlRepository;
+import org.folio.spring.cql.domain.LanguageRespectCaseRespectAccents;
+
+public interface LanguageRespectCaseRespectAccentsRepository
+    extends JpaCqlRepository<LanguageRespectCaseRespectAccents, Integer> {
+}

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-general-it-schema.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-general-it-schema.sql
@@ -1,3 +1,8 @@
+CREATE EXTENSION IF NOT EXISTS unaccent WITH SCHEMA public;
+CREATE OR REPLACE FUNCTION f_unaccent(text) RETURNS text AS $$
+  SELECT public.unaccent('public.unaccent', $1)
+$$ LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT;
+
 DROP TABLE IF EXISTS
   city,
   person,

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-general-it-schema.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-general-it-schema.sql
@@ -1,8 +1,10 @@
 DROP TABLE IF EXISTS
   city,
   person,
-  str;
+  str,
+  lang;
 
 CREATE TABLE city(id INT PRIMARY KEY, name VARCHAR(255));
 CREATE TABLE person(id INT PRIMARY KEY, name VARCHAR(255), age INT, identifier UUID, is_alive boolean, date_born timestamp, local_date timestamp, city_id INT REFERENCES city(id), deleted boolean, created_date timestamp);
 CREATE TABLE str(id INT PRIMARY KEY, str text);
+CREATE TABLE lang(id INT PRIMARY KEY, name VARCHAR(255));

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-lang-ignore-case-test-data.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-lang-ignore-case-test-data.sql
@@ -2,3 +2,4 @@ insert into lang(id, name) values (204, 'Java');
 insert into lang(id, name) values (205, 'jAva');
 insert into lang(id, name) values (206, 'JaVa');
 insert into lang(id, name) values (207, 'javA');
+insert into lang(id, name) values (208, 'python');

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-lang-ignore-case-test-data.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-lang-ignore-case-test-data.sql
@@ -1,5 +1,5 @@
-insert into lang(id, name) values (204, 'Java');
-insert into lang(id, name) values (205, 'jAva');
+insert into lang(id, name) values (204, 'Jâva');
+insert into lang(id, name) values (205, 'Java');
 insert into lang(id, name) values (206, 'JaVa');
 insert into lang(id, name) values (207, 'javA');
 insert into lang(id, name) values (208, 'python');

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-lang-ignore-case-test-data.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-lang-ignore-case-test-data.sql
@@ -1,0 +1,4 @@
+insert into lang(id, name) values (204, 'Java');
+insert into lang(id, name) values (205, 'jAva');
+insert into lang(id, name) values (206, 'JaVa');
+insert into lang(id, name) values (207, 'javA');

--- a/folio-spring-cql/src/test/resources/sql/jpa-cql-lang-ignore-case-test-data.sql
+++ b/folio-spring-cql/src/test/resources/sql/jpa-cql-lang-ignore-case-test-data.sql
@@ -3,3 +3,6 @@ insert into lang(id, name) values (205, 'jAva');
 insert into lang(id, name) values (206, 'JaVa');
 insert into lang(id, name) values (207, 'javA');
 insert into lang(id, name) values (208, 'python');
+insert into lang(id, name) values (209, 'İstanbul++');
+insert into lang(id, name) values (210, 'istanbul++');
+insert into lang(id, name) values (211, 'Istanbul++');


### PR DESCRIPTION
[FOLSPRINGS-185](https://folio-org.atlassian.net/browse/FOLSPRINGS-185)

This implements case ignoring (= case insensitive) and accents ignoring CQL queries for String fields as default for Sunflower.

The back-port to Ramsons and Sunflower will have enable this only if a flag is set so that other modules won't be affected by this breaking change. This flag will be added for the Ramsons and Sunflower back-port only.