### PR TITLE
[FOLSPRINGS-183] Fix user serialization

### DIFF
--- a/folio-spring-system-user/src/main/java/org/folio/spring/client/UsersClient.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/client/UsersClient.java
@@ -58,11 +58,11 @@ public interface UsersClient {
      * We must store these to be able to update the user (in the case of re-activation), otherwise all additional
      * information from mod-users will be lost when re-serializing.
      */
-    @JsonAnyGetter
     @JsonAnySetter
     @Singular("extraProperties")
     private Map<String, Object> extraProperties;
 
+    @JsonAnyGetter
     public Map<String, Object> getExtraProperties() {
       return this.extraProperties;
     }

--- a/folio-spring-system-user/src/test/java/org/folio/spring/client/UsersClientTest.java
+++ b/folio-spring-system-user/src/test/java/org/folio/spring/client/UsersClientTest.java
@@ -31,6 +31,7 @@ public class UsersClientTest {
       User.class
     );
 
+    // we want someOtherProperty moved under extraProperties for deserialization
     assertThat(user)
       .extracting("id", "username", "active", "personal.lastName", "extraProperties.someOtherProperty")
       .containsExactly("id", "username", true, "Smith", "value");
@@ -52,8 +53,11 @@ public class UsersClientTest {
       new TypeReference<HashMap<String, Object>>() {}
     );
 
+    // we want someOtherProperty extracted out of extraProperties for serialization
     assertThat(user)
-      .extracting("id", "username", "active", "personal.lastName", "extraProperties.someOtherProperty")
+      .extracting("id", "username", "active", "personal.lastName", "someOtherProperty")
       .containsExactly("id", "username", true, "Smith", "value");
+
+    assertThat(user).doesNotContainKey("extraProperties");
   }
 }


### PR DESCRIPTION
## Purpose
Resolve a bug occurring during platform build where the `POST /users` request is invalid

```
fatal: [10.36.1.8]: FAILED! => {"changed": false, "connection": "close", "content": "POST request for mod-entities-links-3.2.0-SNAPSHOT.316 /_/tenant failed with 500: {\"errors\":[{\"message\":\"[422 Unprocessable Entity] during [POST] to [http://users/] [UsersClient#createUser(User)]: [{\\\"errors\\\":[{\\\"message\\\":\\\"Unrecognized field \\\\\\\"extraProperties\\\\\\\" (class org.folio.rest.jaxrs.model.User), not marked as ignorable (19 known properties: \\\\\\\"barcode\\\\\\\", \\\\\\\"departments\\\\\\\", \\\\\\\"meta\\\\\\\", \\\\\\\"active\\\\\\\",... (697 bytes)]\",\"type\":\"UnprocessableEntity\",\"code\":\"unknown\",\"parameters\":[]}],\"total_records\":1}", "content_length": "522", "content_type": "text/plain", "elapsed": 156, "msg": "Status code was 400 and not [200]: HTTP Error 400: Bad Request", "redirected": false, "status": 400, "url": "http://10.36.1.8:9130/_/proxy/tenants/diku/install?deploy=true&tenantParameters=loadSample%3Dtrue%2CloadReference%3Dtrue%2CrunReindex%3Dtrue"}
```

## Approach
Proper serialization of the additional user properties