### PR TITLE
[FOLSPRING-183] [system-user] Make login failure during tenant install into a soft failure

### DIFF
--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/PrepareSystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/PrepareSystemUserService.java
@@ -52,16 +52,28 @@ public class PrepareSystemUserService {
       assignPermissions(userId);
       saveCredentials(userId);
 
-      // a nice sanity check, to fail sooner and ensure later logins will go smoothly
-      systemUserService.authSystemUser(folioExecutionContext.getTenantId(),
-                                       systemUserProperties.username(), systemUserProperties.password());
-      log.info("System user authenticated successfully");
+      sanityCheck();
     } catch (RuntimeException e) {
       log.error("Unexpected error while preparing system user with username={}:", systemUserProperties.username(), e);
       throw e;
     }
 
     log.info("Preparing system user is completed!");
+  }
+
+  // attempt to login now, to fail sooner and ensure later logins will go smoothly
+  private void sanityCheck() {
+    try {
+      systemUserService.authSystemUser(folioExecutionContext.getTenantId(),
+                                        systemUserProperties.username(), systemUserProperties.password());
+      log.info("System user authenticated successfully");
+    } catch (FeignException e) {
+      log.error("System user authentication failed, continuing is not recommended!", e);
+      // Feb 2025: we would want to re-throw and fail the module upgrade here,
+      //   however, this broke Karate tests (as mod-authtoken may not be available when the modules
+      //   are being installed), so we are just logging the error for now. This should be revisited
+      //   once Karate tests are updated to handle this case.
+    }
   }
 
   /**


### PR DESCRIPTION
## Purpose
In the improvements to the system user library, a sanity check was added after the system user is created to ensure the system user actually works. This is done by attempting to login as the system user, failing the install if the system user does not work, to ensure we fail sooner and make it easier for implementers and developers to troubleshoot, rather than waiting for a later user-invoked action to result in failure.

However, our integration test (Karate) environments are setup in such a way that, during regular module's install, `mod-authtoken` is not available. `authtoken` is declared as an optional dependency of `login`, so this is technically allowed, however, it makes our attempted login fail. Until this is fixed, we should not fail the module upgrade as described above. 

## Approach
Turn the failure into a log-only message