### PR TITLE
Revert "[FOLSPRING-183] [system-user] Make login failure during tenant install into a soft failure"

### DIFF
--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/PrepareSystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/PrepareSystemUserService.java
@@ -52,28 +52,16 @@ public class PrepareSystemUserService {
       assignPermissions(userId);
       saveCredentials(userId);
 
-      sanityCheck();
+      // a nice sanity check, to fail sooner and ensure later logins will go smoothly
+      systemUserService.authSystemUser(folioExecutionContext.getTenantId(),
+                                       systemUserProperties.username(), systemUserProperties.password());
+      log.info("System user authenticated successfully");
     } catch (RuntimeException e) {
       log.error("Unexpected error while preparing system user with username={}:", systemUserProperties.username(), e);
       throw e;
     }
 
     log.info("Preparing system user is completed!");
-  }
-
-  // attempt to login now, to fail sooner and ensure later logins will go smoothly
-  private void sanityCheck() {
-    try {
-      systemUserService.authSystemUser(folioExecutionContext.getTenantId(),
-                                        systemUserProperties.username(), systemUserProperties.password());
-      log.info("System user authenticated successfully");
-    } catch (RuntimeException e) {
-      log.error("System user authentication failed, continuing is not recommended!", e);
-      // Feb 2025: we would want to re-throw and fail the module upgrade here,
-      //   however, this broke Karate tests (as mod-authtoken may not be available when the modules
-      //   are being installed), so we are just logging the error for now. This should be revisited
-      //   once Karate tests are updated to handle this case.
-    }
   }
 
   /**


### PR DESCRIPTION
This soft failure was only temporary while we waited for Karate tests to get updated. This has now been resolved, so we can restore this check into it's original form.

This reverts #228 and #229 