### PR TITLE
FOLSPRINGS-197 Migrate Log4j plugin registration to annotation processor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,9 @@ DROP INDEX IF EXISTS idx_medreq_requester_barcode;
 CREATE INDEX idx_medreq_requester_barcode ON ${database.defaultSchemaName}.mediated_request(lower(f_unaccent(requester_barcode)));
 ```
 
+### folio-spring-base
+* [FOLSPRINGS-197](https://folio-org.atlassian.net/browse/FOLSPRINGS-197) Migrate Log4j plugin registration to annotation processor
+
 ### cql submodule
 * [FOLSPRINGS-185](https://folio-org.atlassian.net/browse/FOLSPRINGS-185) Implement case insensitive accents ignoring CQL queries
 

--- a/folio-spring-base/src/main/resources/log4j2-json.properties
+++ b/folio-spring-base/src/main/resources/log4j2-json.properties
@@ -1,6 +1,5 @@
 status = error
 name = PropertiesConfig
-packages = org.folio.spring.logging
 
 appenders = console
 

--- a/folio-spring-base/src/main/resources/log4j2.properties
+++ b/folio-spring-base/src/main/resources/log4j2.properties
@@ -1,6 +1,5 @@
 status = error
 name = PropertiesConfig
-packages = org.folio.spring.logging
 
 appenders = console
 

--- a/folio-spring-base/src/test/resources/log4j2-test.xml
+++ b/folio-spring-base/src/test/resources/log4j2-test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="org.folio.spring.filter.appender">
+<Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />

--- a/folio-spring-cql/src/test/resources/log4j2-test.xml
+++ b/folio-spring-cql/src/test/resources/log4j2-test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="org.folio.spring.filter.appender">
+<Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />

--- a/folio-spring-i18n/src/test/resources/log4j2-test.xml
+++ b/folio-spring-i18n/src/test/resources/log4j2-test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="org.folio.spring.filter.appender">
+<Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />

--- a/folio-spring-system-user/src/test/resources/log4j2-test.xml
+++ b/folio-spring-system-user/src/test/resources/log4j2-test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="org.folio.spring.filter.appender">
+<Configuration status="WARN">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />

--- a/pom.xml
+++ b/pom.xml
@@ -265,10 +265,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <release>${java.version}</release>
-            <compilerArgument>-proc:full</compilerArgument>
-            <annotationProcessorPaths>
+        <configuration>
+          <release>${java.version}</release>
+          <compilerArgument>-proc:full</compilerArgument>
+          <annotationProcessorPaths>
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
@@ -283,6 +283,11 @@
               <groupId>org.mapstruct</groupId>
               <artifactId>mapstruct-processor</artifactId>
               <version>${mapstruct.version}</version>
+            </path>
+            <path>
+              <groupId>org.apache.logging.log4j</groupId>
+              <artifactId>log4j-core</artifactId>
+              <version>${log4j2.version}</version>
             </path>
           </annotationProcessorPaths>
         </configuration>


### PR DESCRIPTION
## Purpose
The use of the `packages` field in the Log4j configuration is deprecated. This task aims to remove the usage of this deprecated field and instead register the plugin using the Log4j annotation processor. This ensures forward compatibility with future Log4j versions and aligns with current best practices for plugin registration.

## Learning
https://logging.apache.org/log4j/2.x/manual/plugins.html#plugin-registry)
