### PR TITLE
[FOLSPRINGS-198] [i18n] Support multiple translation search directories

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,9 @@ CREATE INDEX idx_medreq_requester_barcode ON ${database.defaultSchemaName}.media
 ### cql submodule
 * [FOLSPRINGS-185](https://folio-org.atlassian.net/browse/FOLSPRINGS-185) Implement case insensitive accents ignoring CQL queries
 
+### folio-spring-i18n
+* [FOLSPRINGS-198](https://folio-org.atlassian.net/browse/FOLSPRINGS-198) Add support for searching multiple translation directories
+
 ### folio-spring-system-user
 * [FOLSPRINGS-195](https://folio-org.atlassian.net/browse/FOLSPRINGS-195) Add headers parameter to executeSystemUserScoped method
 

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/config/TranslationConfiguration.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/config/TranslationConfiguration.java
@@ -30,7 +30,7 @@ public class TranslationConfiguration {
     this.fallbackLocale = fallbackLocale;
   }
 
-  // BC with versions prior to 10.0.0
+  // compatibility with versions prior to 10.0.0
   public TranslationConfiguration(String translationDirectory, Locale fallbackLocale) {
     this(List.of(translationDirectory), fallbackLocale);
   }

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/config/TranslationConfiguration.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/config/TranslationConfiguration.java
@@ -1,5 +1,6 @@
 package org.folio.spring.i18n.config;
 
+import java.util.List;
 import java.util.Locale;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,16 +17,21 @@ import org.springframework.context.annotation.ComponentScan;
 @ComponentScan(basePackages = "org.folio.spring.i18n.service")
 public class TranslationConfiguration {
 
-  private final String translationDirectory;
+  private final List<String> translationDirectories;
 
   private final Locale fallbackLocale;
 
   @Autowired
   public TranslationConfiguration(
-    @Value("/translations/") String translationDirectory,
+    @Value("#{'/translations/,/custom-translations/'.split(',')}") List<String> translationDirectories,
     @Value("#{T(java.util.Locale).ENGLISH}") Locale fallbackLocale
   ) {
-    this.translationDirectory = translationDirectory;
+    this.translationDirectories = translationDirectories;
     this.fallbackLocale = fallbackLocale;
+  }
+
+  // BC with versions prior to 10.0.0
+  public TranslationConfiguration(String translationDirectory, Locale fallbackLocale) {
+    this(List.of(translationDirectory), fallbackLocale);
   }
 }

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
@@ -362,10 +362,14 @@ public class TranslationService {
    */
   protected List<TranslationFile> getAvailableTranslationFiles() {
     try {
-      Map<String, List<Resource>> localeGroups = Arrays
-        .stream(
-          resourceResolver.getResources(String.format(TRANSLATIONS_CLASSPATH, configuration.getTranslationDirectory()))
-        )
+      List<Resource> resources = new ArrayList<>();
+
+      for (String dir : configuration.getTranslationDirectories()) {
+        resources.addAll(Arrays.asList(resourceResolver.getResources(String.format(TRANSLATIONS_CLASSPATH, dir))));
+      }
+
+      Map<String, List<Resource>> localeGroups = resources
+        .stream()
         .filter(Resource::isReadable)
         .collect(Collectors.groupingBy(Resource::getFilename));
 

--- a/folio-spring-i18n/src/test/java/org/folio/spring/i18n/service/TranslationServiceResolutionTest.java
+++ b/folio-spring-i18n/src/test/java/org/folio/spring/i18n/service/TranslationServiceResolutionTest.java
@@ -31,7 +31,7 @@ class TranslationServiceResolutionTest {
 
   private TranslationService getService(String path) {
     TranslationConfiguration translationConfiguration = new TranslationConfiguration(
-      "/test-translations/test-" + path + "/",
+      List.of("/test-translations/test-" + path + "/"),
       Locale.ENGLISH
     );
 
@@ -78,7 +78,7 @@ class TranslationServiceResolutionTest {
     TranslationService service = new TranslationService(
       new PathMatchingResourcePatternResolver(),
       new TranslationConfiguration(
-        "/test-translations/test-normal/",
+        List.of("/test-translations/test-normal/"),
         Locale.of("test", "")
       )
     );

--- a/folio-spring-i18n/src/test/resources/test-translations/test-combined/mod-bar/test.json
+++ b/folio-spring-i18n/src/test/resources/test-translations/test-combined/mod-bar/test.json
@@ -1,0 +1,3 @@
+{
+  "combined-file-only": "present!"
+}

--- a/folio-spring-i18n/src/test/resources/test-translations/test-combined/mod-baz/test.json
+++ b/folio-spring-i18n/src/test/resources/test-translations/test-combined/mod-baz/test.json
@@ -1,0 +1,3 @@
+{
+  "combined-file-only": "baz present!"
+}

--- a/folio-spring-i18n/src/test/resources/test-translations/test-multiple/mod-bar/en.json
+++ b/folio-spring-i18n/src/test/resources/test-translations/test-multiple/mod-bar/en.json
@@ -1,5 +1,6 @@
 {
   "foo": "[mod-bar] en {test}",
   "en_base_only": "[mod-bar] In en base!",
-  "en_only": "[mod-bar] In en base!"
+  "en_only": "[mod-bar] In en base!",
+  "test_multiple_only": "only in multiple!"
 }


### PR DESCRIPTION
# [Jira FOLSPRINGS-198](https://folio-org.atlassian.net/browse/FOLSPRINGS-198)

## Purpose
Currently `TranslationConfiguration` only supports a single `translationDirectory`; this change allows use of a `List` of `translationDirectories`. Some use cases require searching more than one translations directory (such as `mod-fqm-manager` with [UXPROD-5169](https://folio-org.atlassian.net/browse/UXPROD-5169)).
