### PR TITLE
fix(i18n): failsafe if translation folders do not exist

### DIFF
--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/service/TranslationService.java
@@ -359,7 +359,8 @@ public class TranslationService {
     try {
       return resourceResolver.getResources(String.format(TRANSLATIONS_CLASSPATH, dir));
     } catch (IOException e) {
-      throw log.throwing(new IllegalStateException("Could not retrieve translation files for dir: " + dir, e));
+      log.error("Could not retrieve translation files for dir: {}", dir, e);
+      return new Resource[0];
     }
   }
 

--- a/folio-spring-i18n/src/test/java/org/folio/spring/i18n/service/TranslationServiceGetFilesTest.java
+++ b/folio-spring-i18n/src/test/java/org/folio/spring/i18n/service/TranslationServiceGetFilesTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.List;
@@ -129,12 +128,11 @@ class TranslationServiceGetFilesTest {
   }
 
   @Test
-  void testExceptional() {
+  void testNonexistentDirectoryReturnsEmptyList() {
     TranslationService service = getService("nonexistent");
-    assertThrows(
-      IllegalStateException.class,
-      service::getAvailableTranslationFiles,
-      "Nonexistent folder should result in an error"
-    );
+
+    var actual = service.getAvailableTranslationFiles();
+
+    assertThat(actual, is(empty()));
   }
 }


### PR DESCRIPTION
## Purpose
Do not fail if translation folders do not exist. Fix behaviour introduced in [FOLSPRINGS-198](https://folio-org.atlassian.net/browse/FOLSPRINGS-198)

## Approach
Log instead throwing