### PR TITLE
chore(system-user): deprecate submodule

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@ CREATE INDEX idx_medreq_requester_barcode ON ${database.defaultSchemaName}.media
 
 ### folio-spring-system-user
 * [FOLSPRINGS-195](https://folio-org.atlassian.net/browse/FOLSPRINGS-195) Add headers parameter to executeSystemUserScoped method
+* [FOLSPRINGS-201](https://folio-org.atlassian.net/browse/FOLSPRINGS-195) Deprecate folio-spring-system-user submodule
 
 ## 9.0.0 2025-02-28
 * [FOLSPRINGS-188](https://folio-org.atlassian.net/browse/FOLSPRINGS-188) Upgrade to Java 21

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The library comprises several submodules that are built as separate artifacts (j
 The library includes the following submodules:
 * **folio-spring-base** - provides fundamental functionality for developing FOLIO modules using the Spring framework.
 * **folio-spring-cql** - facilitates CQL querying (refer to the [CQL support](#cql-support) section below)
-* **folio-spring-system-user** - provides [functionality](folio-spring-system-user/README.md) for system-user creation and utilization 
+* ~~**folio-spring-system-user**~~ - (deprecated) provides [functionality](folio-spring-system-user/README.md) for system-user creation and utilization 
 
 ## Execution Context
 

--- a/folio-spring-base/src/main/java/org/folio/spring/exception/FolioContextExecutionException.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/exception/FolioContextExecutionException.java
@@ -1,0 +1,35 @@
+package org.folio.spring.exception;
+
+/**
+ * Exception thrown when an error occurs during Folio context execution.
+ */
+public class FolioContextExecutionException extends RuntimeException {
+
+  /**
+   * Constructs a new FolioContextExecutionException with the specified detail message.
+   *
+   * @param message the detail message
+   */
+  public FolioContextExecutionException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new FolioContextExecutionException with the specified cause.
+   *
+   * @param cause the cause of the exception
+   */
+  public FolioContextExecutionException(Throwable cause) {
+    super(cause);
+  }
+
+  /**
+   * Constructs a new FolioContextExecutionException with the specified detail message and cause.
+   *
+   * @param message the detail message
+   * @param cause the cause of the exception
+   */
+  public FolioContextExecutionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/folio-spring-base/src/main/java/org/folio/spring/scope/FolioExecutionContextService.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/scope/FolioExecutionContextService.java
@@ -1,0 +1,97 @@
+package org.folio.spring.scope;
+
+import static java.util.Collections.singleton;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import lombok.SneakyThrows;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.exception.FolioContextExecutionException;
+import org.folio.spring.integration.XOkapiHeaders;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service for executing code within a Folio context, setting up tenant and headers.
+ */
+@Service
+public class FolioExecutionContextService {
+
+  private final FolioModuleMetadata moduleMetadata;
+
+  /**
+   * Constructs a FolioContextExecutionService with the given module metadata.
+   *
+   * @param moduleMetadata the module metadata to use for context setup
+   */
+  public FolioExecutionContextService(FolioModuleMetadata moduleMetadata) {
+    this.moduleMetadata = moduleMetadata;
+  }
+
+  /**
+   * Executes the given action within a Folio context for the specified tenant and headers.
+   *
+   * @param tenantId the tenant identifier
+   * @param headers the headers to set in the context
+   * @param action the action to execute
+   * @param <T> the return type of the action
+   * @return the result of the action
+   * @throws FolioContextExecutionException if execution fails
+   */
+  public <T> T execute(String tenantId, Map<String, Collection<String>> headers, Callable<T> action) {
+    Map<String, Collection<String>> allHeaders = headers == null ? new HashMap<>() : new HashMap<>(headers);
+    allHeaders.put(XOkapiHeaders.TENANT, singleton(tenantId));
+    try (var fex = new FolioExecutionContextSetter(moduleMetadata, allHeaders)) {
+      return action.call();
+    } catch (Exception e) {
+      throw new FolioContextExecutionException("Execution for tenant = %s failed.".formatted(tenantId), e);
+    }
+  }
+
+  /**
+   * Executes the given action within a Folio context for the specified tenant and execution context.
+   *
+   * @param tenantId the tenant identifier
+   * @param context the Folio execution context to extract headers from and set in the context
+   * @param action the action to execute
+   * @param <T> the return type of the action
+   * @return the result of the action
+   * @throws FolioContextExecutionException if execution fails
+   */
+  @SneakyThrows
+  public <T> T execute(String tenantId, FolioExecutionContext context, Callable<T> action) {
+    return execute(tenantId, context.getAllHeaders(), action);
+  }
+
+  /**
+   * Executes the given runnable action within a Folio context for the specified tenant and headers.
+   *
+   * @param tenantId the tenant identifier
+   * @param headers the headers to set in the context
+   * @param action the runnable action to execute
+   * @throws FolioContextExecutionException if execution fails
+   */
+  public void execute(String tenantId, Map<String, Collection<String>> headers, Runnable action) {
+    execute(tenantId, headers, () -> {
+      action.run();
+      return null;
+    });
+  }
+
+  /**
+   * Executes the given runnable action within a Folio context for the specified tenant and execution context.
+   *
+   * @param tenantId the tenant identifier
+   * @param context the Folio execution context to extract headers from and set in the context
+   * @param action the runnable action to execute
+   * @throws FolioContextExecutionException if execution fails
+   */
+  public void execute(String tenantId, FolioExecutionContext context, Runnable action) {
+    execute(tenantId, context, () -> {
+      action.run();
+      return null;
+    });
+  }
+}

--- a/folio-spring-base/src/test/java/org/folio/spring/exception/FolioContextExecutionExceptionTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/exception/FolioContextExecutionExceptionTest.java
@@ -1,0 +1,38 @@
+package org.folio.spring.exception;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class FolioContextExecutionExceptionTest {
+
+  @Test
+  void testConstructorWithMessage() {
+    String message = "Test message";
+    FolioContextExecutionException ex = new FolioContextExecutionException(message);
+    assertEquals(message, ex.getMessage());
+    assertNull(ex.getCause());
+  }
+
+  @Test
+  void testConstructorWithCause() {
+    Throwable cause = new RuntimeException("Cause");
+    FolioContextExecutionException ex = new FolioContextExecutionException(cause);
+    assertEquals(cause, ex.getCause());
+    assertTrue(ex.getMessage().contains(cause.toString()));
+  }
+
+  @Test
+  void testConstructorWithMessageAndCause() {
+    String message = "Test message";
+    Throwable cause = new RuntimeException("Cause");
+    FolioContextExecutionException ex = new FolioContextExecutionException(message, cause);
+    assertEquals(message, ex.getMessage());
+    assertEquals(cause, ex.getCause());
+  }
+}
+

--- a/folio-spring-base/src/test/java/org/folio/spring/scope/FolioExecutionContextServiceTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/scope/FolioExecutionContextServiceTest.java
@@ -1,0 +1,148 @@
+package org.folio.spring.scope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.exception.FolioContextExecutionException;
+import org.folio.spring.integration.XOkapiHeaders;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class FolioExecutionContextServiceTest {
+
+  private FolioModuleMetadata moduleMetadata;
+  private FolioExecutionContextService service;
+
+  @BeforeEach
+  void setUp() {
+    moduleMetadata = new FolioModuleMetadata() {
+
+      @Override
+      public String getModuleName() {
+        return "test-module";
+      }
+
+      @Override
+      public String getDBSchemaName(String tenantId) {
+        return "public";
+      }
+    };
+    service = new FolioExecutionContextService(moduleMetadata);
+  }
+
+  @Test
+  void execute_callable_success() {
+    String tenantId = "tenantA";
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put("header1", List.of("value1"));
+
+    String result = service.execute(tenantId, headers, () -> {
+      assertContext(tenantId, "header1", "value1");
+      return "success";
+    });
+    assertEquals("success", result);
+  }
+
+  @Test
+  void execute_callable_exception() {
+    String tenantId = "tenantB";
+    Map<String, Collection<String>> headers = new HashMap<>();
+
+    Exception ex = assertThrows(FolioContextExecutionException.class, () ->
+      service.execute(tenantId, headers, () -> {
+        throw new RuntimeException("fail");
+      })
+    );
+    assertTrue(ex.getMessage().contains("tenant = tenantB"));
+    assertInstanceOf(RuntimeException.class, ex.getCause());
+  }
+
+  @Test
+  void execute_runnable_success() {
+    String tenantId = "tenantC";
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put("header2", List.of("value2"));
+    final boolean[] called = {false};
+
+    service.execute(tenantId, headers, () -> {
+      assertContext(tenantId, "header2", "value2");
+      called[0] = true;
+    });
+    assertTrue(called[0]);
+  }
+
+  @Test
+  void execute_runnable_exception() {
+    String tenantId = "tenantD";
+    Map<String, Collection<String>> headers = new HashMap<>();
+
+    Exception ex = assertThrows(FolioContextExecutionException.class, () ->
+      service.execute(tenantId, headers, (Runnable) () -> {
+        throw new RuntimeException("fail");
+      })
+    );
+    assertTrue(ex.getMessage().contains("tenant = tenantD"));
+    assertInstanceOf(RuntimeException.class, ex.getCause());
+  }
+
+  @Test
+  void execute_with_context_success() {
+    String tenantId = "tenantE";
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put("header2", List.of("value2"));
+    FolioExecutionContext context = new FolioExecutionContext() {
+      @Override
+      public Map<String, Collection<String>> getAllHeaders() {
+        return headers;
+      }
+    };
+
+    String result = service.execute(tenantId, context, () -> {
+      assertContext(tenantId, "header2", "value2");
+      return "context-success";
+    });
+    assertEquals("context-success", result);
+  }
+
+  @Test
+  void execute_with_context_runnable_success() {
+    String tenantId = "tenantF";
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put("header2", List.of("value2"));
+    FolioExecutionContext context = new FolioExecutionContext() {
+      @Override
+      public Map<String, Collection<String>> getAllHeaders() {
+        return headers;
+      }
+    };
+    final boolean[] called = {false};
+
+    service.execute(tenantId, context, () -> {
+      assertContext(tenantId, XOkapiHeaders.TENANT, tenantId);
+      called[0] = true;
+    });
+    assertTrue(called[0]);
+  }
+
+  private void assertContext(String tenantId, String additionalHeader, String additionalHeaderValue) {
+    var context = FolioExecutionScopeExecutionContextManager.getFolioExecutionContext();
+    assertThat(context).isNotNull();
+    assertThat(context.getTenantId()).isEqualTo(tenantId);
+    assertThat(context.getAllHeaders())
+      .extracting(map -> map.get(additionalHeader).iterator().next(),
+        map -> map.get(XOkapiHeaders.TENANT).iterator().next())
+      .containsExactly(additionalHeaderValue, tenantId);
+    assertEquals(moduleMetadata, context.getFolioModuleMetadata());
+  }
+}

--- a/folio-spring-system-user/README.md
+++ b/folio-spring-system-user/README.md
@@ -1,5 +1,7 @@
 # Documentation for folio-spring-system-user features
 
+This submodule is deprecated.
+
 ## Creation
 
 If module need system user to communicate with other modules then it's required to create the system

--- a/folio-spring-system-user/pom.xml
+++ b/folio-spring-system-user/pom.xml
@@ -10,7 +10,7 @@
 
   <name>folio-spring-system-user</name>
   <artifactId>folio-spring-system-user</artifactId>
-  <description />
+  <description>Deprecated: This module is no longer maintained.</description>
 
   <dependencies>
     <dependency>

--- a/folio-spring-system-user/src/main/java/org/folio/spring/client/AuthnClient.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/client/AuthnClient.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Deprecated(since = "10.0.0", forRemoval = true)
 @FeignClient(name = "folio-spring-base-authn-client", url = "authn")
 public interface AuthnClient {
 

--- a/folio-spring-system-user/src/main/java/org/folio/spring/client/PermissionsClient.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/client/PermissionsClient.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
+@Deprecated(since = "10.0.0", forRemoval = true)
 @FeignClient(name = "folio-spring-base-permissions-client", url = "perms/users")
 public interface PermissionsClient {
 

--- a/folio-spring-system-user/src/main/java/org/folio/spring/client/UsersClient.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/client/UsersClient.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Deprecated(since = "10.0.0", forRemoval = true)
 @FeignClient(name = "folio-spring-base-users-client", url = "users")
 public interface UsersClient {
   /** Searches for user(s) by CQL query. */

--- a/folio-spring-system-user/src/main/java/org/folio/spring/config/properties/FolioEnvironment.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/config/properties/FolioEnvironment.java
@@ -14,6 +14,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.validation.annotation.Validated;
 
 @Data
+@Deprecated(since = "10.0.0", forRemoval = true)
 @Validated
 @Configuration
 @NoArgsConstructor

--- a/folio-spring-system-user/src/main/java/org/folio/spring/context/ExecutionContextBuilder.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/context/ExecutionContextBuilder.java
@@ -20,6 +20,7 @@ import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.model.SystemUser;
 import org.springframework.stereotype.Component;
 
+@Deprecated(since = "10.0.0", forRemoval = true)
 @Component
 @RequiredArgsConstructor
 public class ExecutionContextBuilder {

--- a/folio-spring-system-user/src/main/java/org/folio/spring/context/SystemUserExecutionContext.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/context/SystemUserExecutionContext.java
@@ -23,6 +23,7 @@ import org.folio.spring.utils.TokenUtils;
  * information about the system user, and is not associated with any particular request.
  */
 @Log4j2
+@Deprecated(since = "10.0.0", forRemoval = true)
 public class SystemUserExecutionContext implements FolioExecutionContext {
 
   private final FolioModuleMetadata moduleMetadata;

--- a/folio-spring-system-user/src/main/java/org/folio/spring/exception/SystemUserAuthorizationException.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/exception/SystemUserAuthorizationException.java
@@ -1,5 +1,6 @@
 package org.folio.spring.exception;
 
+@Deprecated(since = "10.0.0", forRemoval = true)
 public class SystemUserAuthorizationException extends RuntimeException {
   public SystemUserAuthorizationException(String message) {
     super(message);

--- a/folio-spring-system-user/src/main/java/org/folio/spring/model/ResultList.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/model/ResultList.java
@@ -11,6 +11,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
+@Deprecated(since = "10.0.0", forRemoval = true)
 @NoArgsConstructor
 @AllArgsConstructor(staticName = "of")
 @JsonIgnoreProperties("resultInfo")

--- a/folio-spring-system-user/src/main/java/org/folio/spring/model/SystemUser.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/model/SystemUser.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 import lombok.With;
 
 @Builder
+@Deprecated(since = "10.0.0", forRemoval = true)
 public record SystemUser(String username, String okapiUrl, String tenantId,
                          @With UserToken token, @With String userId) {
 }

--- a/folio-spring-system-user/src/main/java/org/folio/spring/model/UserToken.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/model/UserToken.java
@@ -4,5 +4,6 @@ import java.time.Instant;
 import lombok.Builder;
 
 @Builder
+@Deprecated(since = "10.0.0", forRemoval = true)
 public record UserToken(String accessToken, Instant accessTokenExpiration) {
 }

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/PrepareSystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/PrepareSystemUserService.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 
 @Log4j2
+@Deprecated(since = "10.0.0", forRemoval = true)
 @RequiredArgsConstructor
 public class PrepareSystemUserService {
 

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserProperties.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserProperties.java
@@ -10,6 +10,7 @@ import org.springframework.validation.annotation.Validated;
 
 @Data
 @Validated
+@Deprecated(since = "10.0.0", forRemoval = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @ConfigurationProperties("folio.system-user")

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserScopedExecutionService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserScopedExecutionService.java
@@ -13,6 +13,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
+@Deprecated(since = "10.0.0", forRemoval = true)
 @RequiredArgsConstructor
 public class SystemUserScopedExecutionService {
 

--- a/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/service/SystemUserService.java
@@ -29,6 +29,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.util.CollectionUtils;
 
 @Log4j2
+@Deprecated(since = "10.0.0", forRemoval = true)
 @RequiredArgsConstructor
 public class SystemUserService {
 

--- a/folio-spring-system-user/src/main/java/org/folio/spring/utils/TokenUtils.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/utils/TokenUtils.java
@@ -11,6 +11,7 @@ import org.folio.spring.client.AuthnClient;
 import org.folio.spring.model.SystemUser;
 import org.folio.spring.model.UserToken;
 
+@Deprecated(since = "10.0.0", forRemoval = true)
 @UtilityClass
 public class TokenUtils {
 


### PR DESCRIPTION
## Purpose
The system-user submodule was implemented to support cross-module interaction in Okapi-based environments.
In an Eureka-based environment, there is another approach for cross-module interaction integrated into the platform.
This means the system-user submodule is not needed anymore.
The plan is to deprecate it in Trillium and remove it in the next release after Trillium
https://folio-org.atlassian.net/browse/FOLSPRINGS-201
