### PR TITLE
FOLSPRINGS-230: PoC Spring Native-Image Support Part #1 - Add native-image reachability metadata to folio-spring-support

### DIFF
--- a/folio-spring-base/pom.xml
+++ b/folio-spring-base/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>folio-spring-support</artifactId>
-    <version>10.1.0-SNAPSHOT</version>
+    <version>10.1.0-NATIVE</version>
   </parent>
 
   <name>folio-spring-base</name>

--- a/folio-spring-base/src/main/java/org/folio/spring/config/FolioSpringConfiguration.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/config/FolioSpringConfiguration.java
@@ -3,6 +3,8 @@ package org.folio.spring.config;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.nativex.FolioBaseRuntimeHints;
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,11 +13,18 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.context.annotation.Lazy;
 
 @Configuration
 @ComponentScan({"org.folio.spring.controller", "org.folio.spring.config",
   "org.folio.spring.filter", "org.folio.spring.service"})
+@ImportRuntimeHints(FolioBaseRuntimeHints.class)
+@RegisterReflectionForBinding({
+  org.folio.tenant.domain.dto.Error.class,
+  org.folio.tenant.domain.dto.Errors.class,
+  org.folio.tenant.domain.dto.Parameter.class,
+  org.folio.tenant.domain.dto.TenantAttributes.class})
 public class FolioSpringConfiguration {
 
   @Bean

--- a/folio-spring-base/src/main/java/org/folio/spring/nativex/FolioBaseRuntimeHints.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/nativex/FolioBaseRuntimeHints.java
@@ -1,0 +1,69 @@
+package org.folio.spring.nativex;
+
+import static org.springframework.aot.hint.MemberCategory.INVOKE_DECLARED_METHODS;
+import static org.springframework.aot.hint.MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS;
+
+import java.util.List;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.liquibase.FolioPostgresDatabase;
+import org.folio.spring.logging.FolioLoggingContextLookup;
+import org.springframework.aop.SpringProxy;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aot.hint.ExecutableMode;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.core.DecoratingProxy;
+
+/**
+ * GraalVM native-image reachability hints for {@code folio-spring-base}.
+ *
+ * <p>Wired into the context via {@code @ImportRuntimeHints} on
+ * {@link org.folio.spring.config.FolioSpringConfiguration} (an auto-configuration entry point), so
+ * every consuming application inherits these hints automatically during Spring AOT processing.</p>
+ */
+public class FolioBaseRuntimeHints implements RuntimeHintsRegistrar {
+
+  @Override
+  public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+    registerFolioExecutionContextProxy(hints);
+    registerLog4j2Plugin(hints);
+    registerLiquibaseDatabase(hints);
+  }
+
+  /**
+   * {@code FolioExecutionScopeConfig#folioExecutionContext()} is a scoped bean declared with
+   * {@link org.springframework.context.annotation.ScopedProxyMode#INTERFACES}, which produces a JDK
+   * dynamic proxy over the {@link FolioExecutionContext} interface. Spring AOT normally registers
+   * this proxy automatically; this is the explicit, refactor-safe safety net.
+   */
+  private void registerFolioExecutionContextProxy(RuntimeHints hints) {
+    hints.proxies().registerJdkProxy(
+        TypeReference.of(FolioExecutionContext.class),
+        TypeReference.of(SpringProxy.class),
+        TypeReference.of(Advised.class),
+        TypeReference.of(DecoratingProxy.class));
+  }
+
+  /**
+   * {@link FolioLoggingContextLookup} is a custom Log4j2 {@code @Plugin} that Log4j2 instantiates
+   * reflectively via its no-arg constructor (discovered through {@code Log4j2Plugins.dat}). The
+   * log4j-core annotation processor already emits reflect-config for it under
+   * {@code META-INF/native-image/log4j-generated/}; this defensive hint keeps the plugin reachable
+   * even if that generated metadata path changes.
+   */
+  private void registerLog4j2Plugin(RuntimeHints hints) {
+    hints.reflection().registerType(FolioLoggingContextLookup.class,
+        builder -> builder.withConstructor(List.of(), ExecutableMode.INVOKE));
+  }
+
+  /**
+   * {@link FolioPostgresDatabase} is a custom Liquibase {@code Database} registered via
+   * {@code DatabaseFactory.register(...)}. Construction itself is a direct {@code new}, but Liquibase
+   * enumerates registered databases reflectively, so its constructors and methods must stay reachable.
+   */
+  private void registerLiquibaseDatabase(RuntimeHints hints) {
+    hints.reflection().registerType(FolioPostgresDatabase.class,
+        builder -> builder.withMembers(INVOKE_PUBLIC_CONSTRUCTORS, INVOKE_DECLARED_METHODS));
+  }
+}

--- a/folio-spring-base/src/main/java/org/folio/spring/nativex/FolioBaseRuntimeHints.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/nativex/FolioBaseRuntimeHints.java
@@ -3,12 +3,15 @@ package org.folio.spring.nativex;
 import static org.springframework.aot.hint.MemberCategory.INVOKE_DECLARED_METHODS;
 import static org.springframework.aot.hint.MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS;
 
+import java.io.Serializable;
 import java.util.List;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.liquibase.FolioPostgresDatabase;
 import org.folio.spring.logging.FolioLoggingContextLookup;
 import org.springframework.aop.SpringProxy;
 import org.springframework.aop.framework.Advised;
+import org.springframework.aop.framework.AopInfrastructureBean;
+import org.springframework.aop.scope.ScopedObject;
 import org.springframework.aot.hint.ExecutableMode;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
@@ -34,12 +37,25 @@ public class FolioBaseRuntimeHints implements RuntimeHintsRegistrar {
   /**
    * {@code FolioExecutionScopeConfig#folioExecutionContext()} is a scoped bean declared with
    * {@link org.springframework.context.annotation.ScopedProxyMode#INTERFACES}, which produces a JDK
-   * dynamic proxy over the {@link FolioExecutionContext} interface. Spring AOT normally registers
-   * this proxy automatically; this is the explicit, refactor-safe safety net.
+   * dynamic proxy over the {@link FolioExecutionContext} interface plus Spring's scoped-proxy
+   * infrastructure interfaces. Spring AOT normally registers this proxy automatically; this is the
+   * explicit, refactor-safe safety net, using the exact interface set (and order) that Spring's
+   * {@code ScopedProxyFactoryBean} produces at runtime.
+   *
+   * <p>Reflective <em>invocation</em> of the proxy's methods — which the scoped-proxy machinery performs
+   * via {@code Method.invoke} on every accessor call (e.g. {@code getTenantId()}) — cannot be expressed
+   * through the {@link RuntimeHints} API ({@code ProxyHints} registers proxy creation only, not method
+   * invocation on a synthesized proxy). It is therefore shipped as raw reachability metadata in
+   * {@code META-INF/native-image/org.folio/folio-spring-base/reachability-metadata.json}. Without it,
+   * every request fails natively with {@code MissingReflectionRegistrationError} on the first
+   * {@code FolioExecutionContext} accessor.
    */
   private void registerFolioExecutionContextProxy(RuntimeHints hints) {
     hints.proxies().registerJdkProxy(
         TypeReference.of(FolioExecutionContext.class),
+        TypeReference.of(ScopedObject.class),
+        TypeReference.of(Serializable.class),
+        TypeReference.of(AopInfrastructureBean.class),
         TypeReference.of(SpringProxy.class),
         TypeReference.of(Advised.class),
         TypeReference.of(DecoratingProxy.class));

--- a/folio-spring-base/src/main/resources/META-INF/native-image/org.folio/folio-spring-base/reachability-metadata.json
+++ b/folio-spring-base/src/main/resources/META-INF/native-image/org.folio/folio-spring-base/reachability-metadata.json
@@ -1,0 +1,20 @@
+{
+  "comment": "folio-spring-base: FolioExecutionContext is a request-scoped bean exposed via a ScopedProxyMode.INTERFACES JDK proxy. Spring's scoped-proxy machinery invokes the proxy's methods reflectively (Method.invoke) on every accessor call, so the proxy's methods must be registered for reflective invocation. This cannot be expressed through the Spring RuntimeHints API (ProxyHints registers proxy creation only, not method invocation on a synthesized proxy), so it is shipped here as raw reachability metadata. The interface list and order match what Spring's ScopedProxyFactoryBean produces at runtime.",
+  "reflection": [
+    {
+      "type": {
+        "proxy": [
+          "org.folio.spring.FolioExecutionContext",
+          "org.springframework.aop.scope.ScopedObject",
+          "java.io.Serializable",
+          "org.springframework.aop.framework.AopInfrastructureBean",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      },
+      "allDeclaredMethods": true,
+      "allPublicMethods": true
+    }
+  ]
+}

--- a/folio-spring-base/src/test/java/org/folio/spring/nativex/FolioBaseRuntimeHintsTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/nativex/FolioBaseRuntimeHintsTest.java
@@ -1,0 +1,43 @@
+package org.folio.spring.nativex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.liquibase.FolioPostgresDatabase;
+import org.folio.spring.logging.FolioLoggingContextLookup;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.SpringProxy;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.core.DecoratingProxy;
+
+@UnitTest
+class FolioBaseRuntimeHintsTest {
+
+  private final RuntimeHints hints = new RuntimeHints();
+
+  FolioBaseRuntimeHintsTest() {
+    new FolioBaseRuntimeHints().registerHints(hints, getClass().getClassLoader());
+  }
+
+  @Test
+  void registersFolioExecutionContextJdkProxy() {
+    assertThat(RuntimeHintsPredicates.proxies().forInterfaces(
+        FolioExecutionContext.class, SpringProxy.class, Advised.class, DecoratingProxy.class))
+      .accepts(hints);
+  }
+
+  @Test
+  void registersLog4j2PluginReflection() {
+    assertThat(RuntimeHintsPredicates.reflection().onType(FolioLoggingContextLookup.class))
+      .accepts(hints);
+  }
+
+  @Test
+  void registersLiquibaseDatabaseReflection() {
+    assertThat(RuntimeHintsPredicates.reflection().onType(FolioPostgresDatabase.class))
+      .accepts(hints);
+  }
+}

--- a/folio-spring-base/src/test/java/org/folio/spring/nativex/FolioBaseRuntimeHintsTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/nativex/FolioBaseRuntimeHintsTest.java
@@ -2,6 +2,8 @@ package org.folio.spring.nativex;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.liquibase.FolioPostgresDatabase;
 import org.folio.spring.logging.FolioLoggingContextLookup;
@@ -9,6 +11,8 @@ import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.aop.SpringProxy;
 import org.springframework.aop.framework.Advised;
+import org.springframework.aop.framework.AopInfrastructureBean;
+import org.springframework.aop.scope.ScopedObject;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
 import org.springframework.core.DecoratingProxy;
@@ -25,8 +29,22 @@ class FolioBaseRuntimeHintsTest {
   @Test
   void registersFolioExecutionContextJdkProxy() {
     assertThat(RuntimeHintsPredicates.proxies().forInterfaces(
-        FolioExecutionContext.class, SpringProxy.class, Advised.class, DecoratingProxy.class))
+        FolioExecutionContext.class, ScopedObject.class, Serializable.class, AopInfrastructureBean.class,
+        SpringProxy.class, Advised.class, DecoratingProxy.class))
       .accepts(hints);
+  }
+
+  @Test
+  void shipsFolioExecutionContextProxyMethodReflectionMetadata() throws Exception {
+    var resource = "META-INF/native-image/org.folio/folio-spring-base/reachability-metadata.json";
+    try (var in = getClass().getClassLoader().getResourceAsStream(resource)) {
+      assertThat(in).as("raw reachability metadata resource must be present on the classpath").isNotNull();
+      var json = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+      assertThat(json)
+        .contains("org.folio.spring.FolioExecutionContext")
+        .contains("org.springframework.aop.scope.ScopedObject")
+        .contains("\"allDeclaredMethods\": true");
+    }
   }
 
   @Test

--- a/folio-spring-common/pom.xml
+++ b/folio-spring-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>folio-spring-support</artifactId>
-    <version>10.1.0-SNAPSHOT</version>
+    <version>10.1.0-NATIVE</version>
   </parent>
 
   <name>folio-spring-common</name>

--- a/folio-spring-cql/pom.xml
+++ b/folio-spring-cql/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>folio-spring-support</artifactId>
-    <version>10.1.0-SNAPSHOT</version>
+    <version>10.1.0-NATIVE</version>
   </parent>
 
   <name>folio-spring-cql</name>

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlConfiguration.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/JpaCqlConfiguration.java
@@ -1,6 +1,8 @@
 package org.folio.spring.cql;
 
+import org.folio.spring.cql.nativex.JpaCqlRuntimeHints;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @Configuration
@@ -8,6 +10,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
   basePackages = "${folio.jpa.repository.base-packages:org.folio}",
   repositoryFactoryBeanClass = JpaCqlRepositoryFactoryBean.class
 )
+@ImportRuntimeHints(JpaCqlRuntimeHints.class)
 public class JpaCqlConfiguration {
 
 }

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/nativex/JpaCqlRuntimeHints.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/nativex/JpaCqlRuntimeHints.java
@@ -1,0 +1,37 @@
+package org.folio.spring.cql.nativex;
+
+import org.folio.spring.cql.IgnoreAccents;
+import org.folio.spring.cql.IgnoreCase;
+import org.folio.spring.cql.RespectAccents;
+import org.folio.spring.cql.RespectCase;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+
+/**
+ * GraalVM native-image reachability hints for {@code folio-spring-cql}.
+ *
+ * <p>Wired into the context via {@code @ImportRuntimeHints} on
+ * {@link org.folio.spring.cql.JpaCqlConfiguration} (an auto-configuration entry point).</p>
+ */
+public class JpaCqlRuntimeHints implements RuntimeHintsRegistrar {
+
+  @Override
+  public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+    // Cql2JpaCriteria#wrapper reads class-level CQL annotations off the consuming application's
+    // @Entity classes via Class#getAnnotation, so the annotation TYPES must stay reflectively
+    // reachable. (The entity classes themselves are the consumer's responsibility — their reflection
+    // metadata is contributed by Spring Data JPA's AOT processing in the consuming app.)
+    //
+    // Only @RespectAccents/@RespectCase are read today (Cql2JpaCriteria:511-512); @IgnoreAccents and
+    // @IgnoreCase are part of the same public CQL annotation contract and are registered for
+    // completeness so consumer entities annotated with them remain introspectable.
+    hints.reflection().registerType(RespectAccents.class);
+    hints.reflection().registerType(RespectCase.class);
+    hints.reflection().registerType(IgnoreAccents.class);
+    hints.reflection().registerType(IgnoreCase.class);
+
+    // Note: the org.z3950.zing.cql.* parser types (CQLParser, CQLNode, ...) are statically imported
+    // and used by Cql2JpaCriteria, so native-image static analysis already makes them reachable — no
+    // reflection hint is required for them.
+  }
+}

--- a/folio-spring-cql/src/main/java/org/folio/spring/cql/nativex/JpaCqlRuntimeHints.java
+++ b/folio-spring-cql/src/main/java/org/folio/spring/cql/nativex/JpaCqlRuntimeHints.java
@@ -1,7 +1,10 @@
 package org.folio.spring.cql.nativex;
 
+import static org.springframework.aot.hint.MemberCategory.INVOKE_PUBLIC_METHODS;
+
 import org.folio.spring.cql.IgnoreAccents;
 import org.folio.spring.cql.IgnoreCase;
+import org.folio.spring.cql.JpaCqlRepositoryImpl;
 import org.folio.spring.cql.RespectAccents;
 import org.folio.spring.cql.RespectCase;
 import org.springframework.aot.hint.RuntimeHints;
@@ -29,6 +32,17 @@ public class JpaCqlRuntimeHints implements RuntimeHintsRegistrar {
     hints.reflection().registerType(RespectCase.class);
     hints.reflection().registerType(IgnoreAccents.class);
     hints.reflection().registerType(IgnoreCase.class);
+
+    // The CQL query methods (findByCql/countByCql) are contributed to every JpaCqlRepository by the
+    // JpaCqlRepositoryImpl base fragment. Spring Data's AOT repository processor cannot derive them
+    // (they are not name-based queries — "cql" is not an entity property), so it logs a
+    // PropertyReferenceException at build time and does NOT generate an optimized invocation. At runtime
+    // Spring Data therefore falls back to invoking the fragment method reflectively via
+    // RepositoryFragmentMethodInvoker, which fails natively with MissingReflectionRegistrationError unless
+    // the impl's methods are registered for reflective invocation. Register them here so every consuming
+    // repository's CQL search works in the native image.
+    hints.reflection().registerType(JpaCqlRepositoryImpl.class,
+        builder -> builder.withMembers(INVOKE_PUBLIC_METHODS));
 
     // Note: the org.z3950.zing.cql.* parser types (CQLParser, CQLNode, ...) are statically imported
     // and used by Cql2JpaCriteria, so native-image static analysis already makes them reachable — no

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/nativex/JpaCqlRuntimeHintsTest.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/nativex/JpaCqlRuntimeHintsTest.java
@@ -1,0 +1,30 @@
+package org.folio.spring.cql.nativex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.spring.cql.IgnoreAccents;
+import org.folio.spring.cql.IgnoreCase;
+import org.folio.spring.cql.RespectAccents;
+import org.folio.spring.cql.RespectCase;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+
+@UnitTest
+class JpaCqlRuntimeHintsTest {
+
+  private final RuntimeHints hints = new RuntimeHints();
+
+  JpaCqlRuntimeHintsTest() {
+    new JpaCqlRuntimeHints().registerHints(hints, getClass().getClassLoader());
+  }
+
+  @Test
+  void registersCqlAnnotationReflection() {
+    assertThat(RuntimeHintsPredicates.reflection().onType(RespectAccents.class)).accepts(hints);
+    assertThat(RuntimeHintsPredicates.reflection().onType(RespectCase.class)).accepts(hints);
+    assertThat(RuntimeHintsPredicates.reflection().onType(IgnoreAccents.class)).accepts(hints);
+    assertThat(RuntimeHintsPredicates.reflection().onType(IgnoreCase.class)).accepts(hints);
+  }
+}

--- a/folio-spring-cql/src/test/java/org/folio/spring/cql/nativex/JpaCqlRuntimeHintsTest.java
+++ b/folio-spring-cql/src/test/java/org/folio/spring/cql/nativex/JpaCqlRuntimeHintsTest.java
@@ -1,9 +1,11 @@
 package org.folio.spring.cql.nativex;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.aot.hint.MemberCategory.INVOKE_PUBLIC_METHODS;
 
 import org.folio.spring.cql.IgnoreAccents;
 import org.folio.spring.cql.IgnoreCase;
+import org.folio.spring.cql.JpaCqlRepositoryImpl;
 import org.folio.spring.cql.RespectAccents;
 import org.folio.spring.cql.RespectCase;
 import org.folio.spring.testing.type.UnitTest;
@@ -26,5 +28,11 @@ class JpaCqlRuntimeHintsTest {
     assertThat(RuntimeHintsPredicates.reflection().onType(RespectCase.class)).accepts(hints);
     assertThat(RuntimeHintsPredicates.reflection().onType(IgnoreAccents.class)).accepts(hints);
     assertThat(RuntimeHintsPredicates.reflection().onType(IgnoreCase.class)).accepts(hints);
+  }
+
+  @Test
+  void registersJpaCqlRepositoryImplMethodReflection() {
+    assertThat(RuntimeHintsPredicates.reflection().onType(JpaCqlRepositoryImpl.class)
+      .withMemberCategory(INVOKE_PUBLIC_METHODS)).accepts(hints);
   }
 }

--- a/folio-spring-i18n/pom.xml
+++ b/folio-spring-i18n/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>folio-spring-support</artifactId>
-    <version>10.1.0-SNAPSHOT</version>
+    <version>10.1.0-NATIVE</version>
   </parent>
 
   <name>folio-spring-i18n</name>

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/config/TranslationConfiguration.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/config/TranslationConfiguration.java
@@ -3,10 +3,12 @@ package org.folio.spring.i18n.config;
 import java.util.List;
 import java.util.Locale;
 import lombok.Getter;
+import org.folio.spring.i18n.nativex.TranslationRuntimeHints;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ImportRuntimeHints;
 
 /**
  * An {@link org.springframework.context.annotation.Configuration Configuration} bean to hold the
@@ -15,6 +17,7 @@ import org.springframework.context.annotation.ComponentScan;
 @Getter
 @AutoConfiguration
 @ComponentScan(basePackages = "org.folio.spring.i18n.service")
+@ImportRuntimeHints(TranslationRuntimeHints.class)
 public class TranslationConfiguration {
 
   private final List<String> translationDirectories;

--- a/folio-spring-i18n/src/main/java/org/folio/spring/i18n/nativex/TranslationRuntimeHints.java
+++ b/folio-spring-i18n/src/main/java/org/folio/spring/i18n/nativex/TranslationRuntimeHints.java
@@ -1,0 +1,29 @@
+package org.folio.spring.i18n.nativex;
+
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+
+/**
+ * GraalVM native-image reachability hints for {@code folio-spring-i18n}.
+ *
+ * <p>Wired into the context via {@code @ImportRuntimeHints} on
+ * {@link org.folio.spring.i18n.config.TranslationConfiguration} (an auto-configuration entry point).</p>
+ */
+public class TranslationRuntimeHints implements RuntimeHintsRegistrar {
+
+  @Override
+  public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+    // TranslationService enumerates translation files at runtime via
+    // ResourcePatternResolver.getResources("classpath:%s*/*.json") for each configured directory.
+    // The default directories (TranslationConfiguration) are "/translations/" and
+    // "/custom-translations/", so the resolved patterns are translations/<module>/<locale>.json and
+    // custom-translations/<module>/<locale>.json. Native-image does not scan the classpath at
+    // runtime — these resource paths must be declared as patterns.
+    hints.resources().registerPattern("translations/*/*.json");
+    hints.resources().registerPattern("custom-translations/*/*.json");
+
+    // ICU4J (com.ibm.icu:icu4j) locale data is bundled as resources. Recent ICU4J ships its own
+    // GraalVM metadata; only add hints.resources().registerPattern("com/ibm/icu/impl/data/icudt*/*")
+    // here if `native:compile` / list-libraries-missing-metadata reports ICU4J as missing.
+  }
+}

--- a/folio-spring-i18n/src/test/java/org/folio/spring/i18n/nativex/TranslationRuntimeHintsTest.java
+++ b/folio-spring-i18n/src/test/java/org/folio/spring/i18n/nativex/TranslationRuntimeHintsTest.java
@@ -1,0 +1,26 @@
+package org.folio.spring.i18n.nativex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+
+@UnitTest
+class TranslationRuntimeHintsTest {
+
+  private final RuntimeHints hints = new RuntimeHints();
+
+  TranslationRuntimeHintsTest() {
+    new TranslationRuntimeHints().registerHints(hints, getClass().getClassLoader());
+  }
+
+  @Test
+  void registersTranslationResourcePatterns() {
+    assertThat(RuntimeHintsPredicates.resource().forResource("translations/mod-foo/en.json"))
+      .accepts(hints);
+    assertThat(RuntimeHintsPredicates.resource().forResource("custom-translations/mod-foo/en.json"))
+      .accepts(hints);
+  }
+}

--- a/folio-spring-system-user/pom.xml
+++ b/folio-spring-system-user/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>folio-spring-support</artifactId>
-    <version>10.1.0-SNAPSHOT</version>
+    <version>10.1.0-NATIVE</version>
   </parent>
 
   <name>folio-spring-system-user</name>

--- a/folio-spring-system-user/src/main/java/org/folio/spring/config/SystemUserConfig.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/config/SystemUserConfig.java
@@ -2,12 +2,15 @@ package org.folio.spring.config;
 
 import lombok.extern.log4j.Log4j2;
 import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.nativex.SystemUserRuntimeHints;
 import org.folio.spring.service.PrepareSystemUserService;
 import org.folio.spring.service.SystemUserProperties;
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
@@ -21,6 +24,16 @@ import org.springframework.core.annotation.Order;
   "org.folio.spring.config.properties",
 })
 @EnableConfigurationProperties({SystemUserProperties.class})
+@ImportRuntimeHints(SystemUserRuntimeHints.class)
+@RegisterReflectionForBinding({
+  org.folio.spring.client.AuthnClient.UserCredentials.class,
+  org.folio.spring.client.AuthnClient.LoginResponse.class,
+  org.folio.spring.client.UsersClient.User.class,
+  org.folio.spring.client.PermissionsClient.Permission.class,
+  org.folio.spring.client.PermissionsClient.Permissions.class,
+  org.folio.spring.model.ResultList.class,
+  org.folio.spring.model.SystemUser.class,
+  org.folio.spring.model.UserToken.class})
 public class SystemUserConfig {
 
   @Bean

--- a/folio-spring-system-user/src/main/java/org/folio/spring/nativex/SystemUserRuntimeHints.java
+++ b/folio-spring-system-user/src/main/java/org/folio/spring/nativex/SystemUserRuntimeHints.java
@@ -1,0 +1,42 @@
+package org.folio.spring.nativex;
+
+import org.folio.spring.client.AuthnClient;
+import org.folio.spring.client.PermissionsClient;
+import org.folio.spring.client.UsersClient;
+import org.springframework.aop.SpringProxy;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+import org.springframework.core.DecoratingProxy;
+
+/**
+ * GraalVM native-image reachability hints for {@code folio-spring-system-user}.
+ *
+ * <p>Wired into the context via {@code @ImportRuntimeHints} on
+ * {@link org.folio.spring.config.SystemUserConfig} (an auto-configuration entry point). Note this
+ * module is {@code @Deprecated(forRemoval = true)}; the hints are provided so the library stays
+ * native-correct for consumers that still depend on it (e.g. {@code mod-roles-keycloak}).</p>
+ */
+public class SystemUserRuntimeHints implements RuntimeHintsRegistrar {
+
+  @Override
+  public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+    // The three @HttpExchange clients are created imperatively via
+    // HttpServiceProxyFactory.createClient(...) in OptionalSystemUserConfig. Unlike declarative
+    // @ImportHttpServices registration, imperative creation does NOT get automatic AOT proxy hints,
+    // so the JDK dynamic proxies these clients run behind must be registered explicitly. The proxy
+    // interface set matches what Spring's ProxyFactory generates for an AOP interface proxy.
+    for (var client : new Class<?>[] {AuthnClient.class, UsersClient.class, PermissionsClient.class}) {
+      hints.proxies().registerJdkProxy(
+          TypeReference.of(client),
+          TypeReference.of(SpringProxy.class),
+          TypeReference.of(Advised.class),
+          TypeReference.of(DecoratingProxy.class));
+    }
+
+    // TokenUtils calls io.netty...ServerCookieDecoder.STRICT / Cookie directly (static calls, not
+    // reflection), so those types are reachable via static analysis; Netty's own internal reflection
+    // is covered by the GraalVM reachability metadata repository. No explicit Netty hint added here.
+  }
+}

--- a/folio-spring-system-user/src/test/java/org/folio/spring/nativex/SystemUserRuntimeHintsTest.java
+++ b/folio-spring-system-user/src/test/java/org/folio/spring/nativex/SystemUserRuntimeHintsTest.java
@@ -1,0 +1,34 @@
+package org.folio.spring.nativex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.spring.client.AuthnClient;
+import org.folio.spring.client.PermissionsClient;
+import org.folio.spring.client.UsersClient;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.SpringProxy;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.core.DecoratingProxy;
+
+@UnitTest
+class SystemUserRuntimeHintsTest {
+
+  private final RuntimeHints hints = new RuntimeHints();
+
+  SystemUserRuntimeHintsTest() {
+    new SystemUserRuntimeHints().registerHints(hints, getClass().getClassLoader());
+  }
+
+  @Test
+  void registersHttpClientJdkProxies() {
+    assertThat(RuntimeHintsPredicates.proxies().forInterfaces(
+        AuthnClient.class, SpringProxy.class, Advised.class, DecoratingProxy.class)).accepts(hints);
+    assertThat(RuntimeHintsPredicates.proxies().forInterfaces(
+        UsersClient.class, SpringProxy.class, Advised.class, DecoratingProxy.class)).accepts(hints);
+    assertThat(RuntimeHintsPredicates.proxies().forInterfaces(
+        PermissionsClient.class, SpringProxy.class, Advised.class, DecoratingProxy.class)).accepts(hints);
+  }
+}

--- a/folio-spring-tenant-settings/pom.xml
+++ b/folio-spring-tenant-settings/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>folio-spring-support</artifactId>
-    <version>10.1.0-SNAPSHOT</version>
+    <version>10.1.0-NATIVE</version>
   </parent>
 
   <artifactId>folio-spring-tenant-settings</artifactId>

--- a/folio-spring-tenant-settings/src/main/java/org/folio/tenant/settings/config/TenantSettingsConfig.java
+++ b/folio-spring-tenant-settings/src/main/java/org/folio/tenant/settings/config/TenantSettingsConfig.java
@@ -1,8 +1,11 @@
 package org.folio.tenant.settings.config;
 
+import org.folio.tenant.settings.nativex.TenantSettingsRuntimeHints;
+import org.springframework.aot.hint.annotation.RegisterReflectionForBinding;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 /**
@@ -13,5 +16,13 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @EntityScan(basePackages = "org.folio")
 @ComponentScan("org.folio.tenant.settings")
 @EnableConfigurationProperties(TenantSettingsProperties.class)
+@ImportRuntimeHints(TenantSettingsRuntimeHints.class)
+@RegisterReflectionForBinding({
+  org.folio.tenant.domain.dto.Setting.class,
+  org.folio.tenant.domain.dto.SettingCollection.class,
+  org.folio.tenant.domain.dto.SettingGroup.class,
+  org.folio.tenant.domain.dto.SettingGroupCollection.class,
+  org.folio.tenant.domain.dto.SettingUpdateRequest.class,
+  org.folio.tenant.domain.dto.Metadata.class})
 public class TenantSettingsConfig {
 }

--- a/folio-spring-tenant-settings/src/main/java/org/folio/tenant/settings/nativex/TenantSettingsRuntimeHints.java
+++ b/folio-spring-tenant-settings/src/main/java/org/folio/tenant/settings/nativex/TenantSettingsRuntimeHints.java
@@ -1,0 +1,27 @@
+package org.folio.tenant.settings.nativex;
+
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+
+/**
+ * GraalVM native-image reachability hints for {@code folio-spring-tenant-settings}.
+ *
+ * <p>Wired into the context via {@code @ImportRuntimeHints} on
+ * {@link org.folio.tenant.settings.config.TenantSettingsConfig} (an auto-configuration entry point).</p>
+ */
+public class TenantSettingsRuntimeHints implements RuntimeHintsRegistrar {
+
+  @Override
+  public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+    // Liquibase loads this changelog from the classpath (consumers include it via
+    // <include file="db/tenant-settings/changelog.xml"/>); native-image does not enumerate the
+    // classpath at runtime, so it must be declared. The file is self-contained (no nested <include>),
+    // so registering the single path is sufficient.
+    hints.resources().registerPattern("db/tenant-settings/changelog.xml");
+
+    // Entity reflection (SettingEntity, its nested SettingType enum, SettingGroupEntity) is contributed
+    // automatically by Hibernate's AOT processing when the consuming application builds its persistence
+    // unit (entities are picked up via @EntityScan). Per the migration plan we rely on that and add an
+    // explicit entity registrar here only if a native smoke test reports the metadata as missing.
+  }
+}

--- a/folio-spring-tenant-settings/src/test/java/org/folio/tenant/settings/nativex/TenantSettingsRuntimeHintsTest.java
+++ b/folio-spring-tenant-settings/src/test/java/org/folio/tenant/settings/nativex/TenantSettingsRuntimeHintsTest.java
@@ -1,0 +1,24 @@
+package org.folio.tenant.settings.nativex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+
+@UnitTest
+class TenantSettingsRuntimeHintsTest {
+
+  private final RuntimeHints hints = new RuntimeHints();
+
+  TenantSettingsRuntimeHintsTest() {
+    new TenantSettingsRuntimeHints().registerHints(hints, getClass().getClassLoader());
+  }
+
+  @Test
+  void registersChangelogResource() {
+    assertThat(RuntimeHintsPredicates.resource().forResource("db/tenant-settings/changelog.xml"))
+      .accepts(hints);
+  }
+}

--- a/folio-spring-testing/pom.xml
+++ b/folio-spring-testing/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.folio</groupId>
     <artifactId>folio-spring-support</artifactId>
-    <version>10.1.0-SNAPSHOT</version>
+    <version>10.1.0-NATIVE</version>
   </parent>
 
   <artifactId>folio-spring-testing</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>folio-spring-support</artifactId>
-  <version>10.1.0-SNAPSHOT</version>
+  <version>10.1.0-NATIVE</version>
   <name>folio-spring-support</name>
   <description>This is a library (jar) that contains the basic functionality and main dependencies required for
     development FOLIO modules using a Spring framework.


### PR DESCRIPTION
## Purpose

`folio-spring-support` sits at the base of the dependency chain, so without shipped GraalVM metadata every downstream module would have to re-discover and re-declare the same low-level hints. This part makes the library contribute its own reachability metadata so consumers inherit it automatically.

US: [FOLSPRINGS-230](https://folio-org.atlassian.net/browse/FOLSPRINGS-230)

## Approach

Each sub-module now contributes the GraalVM hints for the types, resources and proxies it owns, wired to its existing autoconfiguration so consumers pick them up with no extra setup. A `native` Maven profile is added but stays inert for ordinary JVM builds, so nothing changes for existing users. Where the `RuntimeHints` API cannot express what is needed, the metadata is shipped as a checked-in file instead.

- Added a `RuntimeHintsRegistrar` per sub-module (base, CQL, i18n, system-user, tenant-settings), each wired via `@ImportRuntimeHints` on that module's autoconfiguration so hints propagate to consumers automatically.
- Added an inert `native` Maven profile; standard `mvn verify` behaviour is unchanged.
- Shipped raw reachability metadata for the request-scoped `FolioExecutionContext` JDK proxy. `RuntimeHints` can register a proxy for *creation* but cannot mark its methods for reflective *invocation*, which the scoped-proxy machinery performs on every accessor.
- Registered the CQL repository fragment for method reflection, because Spring Data AOT cannot derive those methods and falls back to invoking the fragment reflectively at runtime.

## Learnings

- **Hints belong with the code that owns the construct.** Both the scoped-proxy and CQL-fragment gaps first surfaced in a consuming module; fixing them here means every consumer inherits the fix instead of repeating it.
- **The `RuntimeHints` API cannot express everything.** Proxy *method* reflection needs raw metadata, so a library may legitimately need both a registrar and a checked-in metadata file.
- **Some gaps only appear under real traffic.** These two were invisible at boot and only showed up on authenticated requests and CQL-query endpoints — a native image that starts is not a validated one.

## Pre-Review Checklist

- [x] **Self-reviewed Code** — Reviewed code for issues, unnecessary parts, and overall quality.
- [ ] **Change Notes** — NEWS.md updated with clear description and issue key.
- [x] **Testing** — Confirmed changes were tested locally or on dev environment.
- [ ] **Dependent module build verification** — Ran manually when library changes impact downstream modules.
  > Actions → Verify Dependent Modules → Run workflow → select branch → Run.
- [ ] **Breaking Changes (if any)** — Handled if changes affect integration with other services.
- [ ] **New Properties / Environment Variables** — Updated README.md if new configs were added.
- [ ] **Environment Recreation Test (if needed)** — Verified that environment can be recreated successfully.

> Draft: part 1 of a 3-repo PoC chain (FOLSPRINGS-230 → APPPOCTOOL-93 → MODROLESKC-412). Not for merge until the whole chain is signed off; NEWS.md entry still to be added.
