### PR TITLE
fix: make execution context header lookups case-insensitive

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * [FOLIO-4553](https://folio-org.atlassian.net/browse/FOLIO-4553) Set "permissions: contents: read" in maven.yml
 
+### folio-spring-base
+* [FOLSPRINGS-234](https://folio-org.atlassian.net/browse/FOLSPRINGS-234) Make execution context header lookups case-insensitive
+
 ## 10.0.0 2026-04-06
 
 **Breaking Changes:**

--- a/folio-spring-base/src/main/java/org/folio/spring/DefaultFolioExecutionContext.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/DefaultFolioExecutionContext.java
@@ -6,17 +6,18 @@ import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.TOKEN;
 import static org.folio.spring.integration.XOkapiHeaders.URL;
 import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
+import static org.folio.spring.utils.FolioExecutionContextUtils.caseInsensitiveCopyOf;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.ToString;
-import org.folio.spring.integration.XOkapiHeaders;
+import org.springframework.util.LinkedCaseInsensitiveMap;
 
 @Getter
 @ToString
@@ -35,9 +36,9 @@ public class DefaultFolioExecutionContext implements FolioExecutionContext {
   public DefaultFolioExecutionContext(FolioModuleMetadata folioModuleMetadata,
     Map<String, Collection<String>> allHeaders) {
     this.folioModuleMetadata = folioModuleMetadata;
-    this.allHeaders = allHeaders;
-    this.okapiHeaders = new HashMap<>(allHeaders);
-    this.okapiHeaders.entrySet().removeIf(e -> !e.getKey().toLowerCase().startsWith(OKAPI_HEADERS_PREFIX));
+    this.allHeaders = caseInsensitiveCopyOf(allHeaders);
+    this.okapiHeaders = caseInsensitiveCopyOf(allHeaders);
+    this.okapiHeaders.entrySet().removeIf(e -> !e.getKey().toLowerCase(Locale.ROOT).startsWith(OKAPI_HEADERS_PREFIX));
 
     this.tenantId = retrieveFirstSafe(okapiHeaders.get(TENANT));
     this.okapiUrl = retrieveFirstSafe(okapiHeaders.get(URL));
@@ -48,10 +49,6 @@ public class DefaultFolioExecutionContext implements FolioExecutionContext {
     this.userId = userIdString.isEmpty() ? null : UUID.fromString(userIdString);
   }
 
-  private String retrieveFirstSafe(Collection<String> strings) {
-    return strings != null && !strings.isEmpty() ? strings.iterator().next() : "";
-  }
-
   public static DefaultFolioExecutionContext fromMessageHeaders(FolioModuleMetadata folioModuleMetadata,
     Map<String, Object> messageHeaders) {
     return new DefaultFolioExecutionContext(folioModuleMetadata, toOkapiHeaders(messageHeaders));
@@ -60,13 +57,17 @@ public class DefaultFolioExecutionContext implements FolioExecutionContext {
   private static Map<String, Collection<String>> toOkapiHeaders(Map<String, Object> messageHeaders) {
     return messageHeaders.entrySet()
       .stream()
-      .filter(e -> e.getKey().startsWith(XOkapiHeaders.OKAPI_HEADERS_PREFIX))
+      .filter(e -> e.getKey().toLowerCase(Locale.ROOT).startsWith(OKAPI_HEADERS_PREFIX))
       .collect(Collectors.toMap(Map.Entry::getKey, e -> {
         Object x = e.getValue();
         if (x instanceof byte[] bytes) {
           return List.of(new String(bytes, StandardCharsets.UTF_8));
         }
         return List.of(String.valueOf(x));
-      }));
+      }, (s, s2) -> s, () -> new LinkedCaseInsensitiveMap<>(Locale.ROOT)));
+  }
+
+  private static String retrieveFirstSafe(Collection<String> strings) {
+    return strings != null && !strings.isEmpty() ? strings.iterator().next() : "";
   }
 }

--- a/folio-spring-base/src/main/java/org/folio/spring/scope/FolioExecutionContextService.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/scope/FolioExecutionContextService.java
@@ -3,7 +3,6 @@ package org.folio.spring.scope;
 import static java.util.Collections.singleton;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import lombok.SneakyThrows;
@@ -11,6 +10,7 @@ import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.exception.FolioContextExecutionException;
 import org.folio.spring.integration.XOkapiHeaders;
+import org.folio.spring.utils.FolioExecutionContextUtils;
 
 /**
  * Service for executing code within a Folio context, setting up tenant and headers.
@@ -39,7 +39,7 @@ public class FolioExecutionContextService {
    * @throws FolioContextExecutionException if execution fails
    */
   public <T> T execute(String tenantId, Map<String, Collection<String>> headers, Callable<T> action) {
-    Map<String, Collection<String>> allHeaders = headers == null ? new HashMap<>() : new HashMap<>(headers);
+    var allHeaders = FolioExecutionContextUtils.caseInsensitiveCopyOf(headers);
     allHeaders.put(XOkapiHeaders.TENANT, singleton(tenantId));
     try (var fex = new FolioExecutionContextSetter(moduleMetadata, allHeaders)) {
       return action.call();

--- a/folio-spring-base/src/main/java/org/folio/spring/utils/FolioExecutionContextUtils.java
+++ b/folio-spring-base/src/main/java/org/folio/spring/utils/FolioExecutionContextUtils.java
@@ -2,30 +2,37 @@ package org.folio.spring.utils;
 
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.lang3.SerializationUtils;
 import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
+import org.springframework.util.LinkedCaseInsensitiveMap;
 
 @Log4j2
 @UtilityClass
 public class FolioExecutionContextUtils {
-  public static FolioExecutionContext prepareContextForTenant(String tenantId, FolioModuleMetadata folioModuleMetadata,
-    FolioExecutionContext context) {
-    if (MapUtils.isNotEmpty(context.getOkapiHeaders())) {
-      // create deep copy of headers in order to make switching context thread safe
-      var headersCopy = SerializationUtils.clone((HashMap<String, Collection<String>>) context.getAllHeaders());
-      headersCopy.entrySet().removeIf(e -> TENANT.equalsIgnoreCase(e.getKey()));
+  public static FolioExecutionContext prepareContextForTenant(String tenantId,
+                                                              FolioModuleMetadata folioModuleMetadata,
+                                                              FolioExecutionContext context) {
+    if (MapUtils.isNotEmpty(context.getAllHeaders())) {
+      var headersCopy = caseInsensitiveCopyOf(context.getAllHeaders());
       headersCopy.put(TENANT, List.of(tenantId));
       log.debug("FOLIO context initialized with tenant {}", tenantId);
       return new DefaultFolioExecutionContext(folioModuleMetadata, headersCopy);
     }
     throw new IllegalStateException("Okapi headers not provided");
+  }
+
+  public static <V> LinkedCaseInsensitiveMap<V> caseInsensitiveCopyOf(Map<String, V> source) {
+    var result = new LinkedCaseInsensitiveMap<V>(Locale.ROOT);
+    if (source != null) {
+      result.putAll(source);
+    }
+    return result;
   }
 }

--- a/folio-spring-base/src/test/java/org/folio/spring/DefaultFolioExecutionContextTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/DefaultFolioExecutionContextTest.java
@@ -8,6 +8,7 @@ import static org.folio.spring.integration.XOkapiHeaders.TOKEN;
 import static org.folio.spring.integration.XOkapiHeaders.URL;
 import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -77,5 +78,87 @@ class DefaultFolioExecutionContextTest {
     };
 
     assertThat(actual).satisfies(contextRequirements);
+  }
+
+  @Test
+  void allHeadersAllowCaseInsensitiveLookup() {
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put(TENANT, singleton("diku"));
+    headers.put("Accept", singleton("application/json"));
+
+    var context = new DefaultFolioExecutionContext(moduleMetadata, headers);
+
+    assertThat(context.getAllHeaders().get("X-Okapi-Tenant")).containsOnly("diku");
+    assertThat(context.getAllHeaders().get("X-OKAPI-TENANT")).containsOnly("diku");
+    assertThat(context.getAllHeaders().get("accept")).containsOnly("application/json");
+    assertThat(context.getAllHeaders().get("ACCEPT")).containsOnly("application/json");
+  }
+
+  @Test
+  void okapiHeadersAllowCaseInsensitiveLookup() {
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put(TENANT, singleton("diku"));
+    headers.put(TOKEN, singleton("my-token"));
+
+    var context = new DefaultFolioExecutionContext(moduleMetadata, headers);
+
+    assertThat(context.getOkapiHeaders().get("X-Okapi-Tenant")).containsOnly("diku");
+    assertThat(context.getOkapiHeaders().get("X-OKAPI-TOKEN")).containsOnly("my-token");
+  }
+
+  @Test
+  void fromMessageHeadersExtractsOkapiHeaders() {
+    var tenant = "diku";
+    var token = "my-token";
+    Map<String, Object> messageHeaders = new HashMap<>();
+    messageHeaders.put(TENANT, tenant);
+    messageHeaders.put(TOKEN, token);
+    messageHeaders.put("Accept", "application/json");
+
+    var context = DefaultFolioExecutionContext.fromMessageHeaders(moduleMetadata, messageHeaders);
+
+    assertThat(context.getTenantId()).isEqualTo(tenant);
+    assertThat(context.getToken()).isEqualTo(token);
+    assertThat(context.getOkapiHeaders()).containsOnlyKeys(TENANT, TOKEN);
+  }
+
+  @Test
+  void fromMessageHeadersDecodesByteArrayValues() {
+    var tenant = "diku";
+    Map<String, Object> messageHeaders = new HashMap<>();
+    messageHeaders.put(TENANT, tenant.getBytes(StandardCharsets.UTF_8));
+
+    var context = DefaultFolioExecutionContext.fromMessageHeaders(moduleMetadata, messageHeaders);
+
+    assertThat(context.getTenantId()).isEqualTo(tenant);
+  }
+
+  @Test
+  void constructorExtractsFieldsFromMixedCaseOkapiHeaderKeys() {
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put("X-Okapi-Tenant", singleton("diku"));
+    headers.put("X-Okapi-Token", singleton("my-token"));
+    headers.put("X-Okapi-Url", singleton("http://okapi.com"));
+
+    var context = new DefaultFolioExecutionContext(moduleMetadata, headers);
+
+    assertThat(context.getTenantId()).isEqualTo("diku");
+    assertThat(context.getToken()).isEqualTo("my-token");
+    assertThat(context.getOkapiUrl()).isEqualTo("http://okapi.com");
+    assertThat(context.getOkapiHeaders()).containsOnlyKeys("X-Okapi-Tenant", "X-Okapi-Token", "X-Okapi-Url");
+  }
+
+  @Test
+  void fromMessageHeadersHandlesMixedCaseOkapiHeaderKeys() {
+    Map<String, Object> messageHeaders = new HashMap<>();
+    messageHeaders.put("X-Okapi-Tenant", "diku");
+    messageHeaders.put("X-Okapi-Token", "my-token");
+    messageHeaders.put("Accept", "application/json");
+
+    var context = DefaultFolioExecutionContext.fromMessageHeaders(moduleMetadata, messageHeaders);
+
+    assertThat(context.getTenantId()).isEqualTo("diku");
+    assertThat(context.getToken()).isEqualTo("my-token");
+    assertThat(context.getOkapiHeaders()).containsOnlyKeys("X-Okapi-Tenant", "X-Okapi-Token");
   }
 }

--- a/folio-spring-base/src/test/java/org/folio/spring/scope/FolioExecutionContextServiceTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/scope/FolioExecutionContextServiceTest.java
@@ -135,6 +135,42 @@ class FolioExecutionContextServiceTest {
     assertTrue(called[0]);
   }
 
+  @Test
+  void execute_with_null_headers_sets_tenant() {
+    String tenantId = "tenantG";
+
+    service.execute(tenantId, (Map<String, Collection<String>>) null, () -> {
+      var context = FolioExecutionScopeExecutionContextManager.getFolioExecutionContext();
+      assertThat(context.getTenantId()).isEqualTo(tenantId);
+    });
+  }
+
+  @Test
+  void execute_with_mixed_case_headers_accessible_inside_action() {
+    String tenantId = "tenantH";
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put("X-Okapi-Token", List.of("my-token"));
+
+    service.execute(tenantId, headers, () -> {
+      var context = FolioExecutionScopeExecutionContextManager.getFolioExecutionContext();
+      assertThat(context.getTenantId()).isEqualTo(tenantId);
+      assertThat(context.getToken()).isEqualTo("my-token");
+    });
+  }
+
+  @Test
+  void execute_tenant_parameter_overrides_tenant_in_headers() {
+    String headerTenant = "old-tenant";
+    String newTenant = "new-tenant";
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put(XOkapiHeaders.TENANT, List.of(headerTenant));
+
+    service.execute(newTenant, headers, () -> {
+      var context = FolioExecutionScopeExecutionContextManager.getFolioExecutionContext();
+      assertThat(context.getTenantId()).isEqualTo(newTenant);
+    });
+  }
+
   private void assertContext(String tenantId, String additionalHeader, String additionalHeaderValue) {
     var context = FolioExecutionScopeExecutionContextManager.getFolioExecutionContext();
     assertThat(context).isNotNull();

--- a/folio-spring-base/src/test/java/org/folio/spring/utils/FolioExecutionContextUtilsTest.java
+++ b/folio-spring-base/src/test/java/org/folio/spring/utils/FolioExecutionContextUtilsTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 
 @UnitTest
 class FolioExecutionContextUtilsTest {
+
   private final FolioModuleMetadata moduleMetadata = new FolioModuleMetadata() {
     @Override public String getModuleName() {
       return "test";
@@ -54,5 +55,34 @@ class FolioExecutionContextUtilsTest {
 
     assertThrows(IllegalStateException.class,
       () -> FolioExecutionContextUtils.prepareContextForTenant(newTenant, moduleMetadata, folioContext));
+  }
+
+  @Test
+  void testPrepareContextForTenantDoesNotMutateOriginalContext() {
+    var originalTenant = "original";
+    var newTenant = "switched";
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put(TENANT, singleton(originalTenant));
+    var folioContext = new DefaultFolioExecutionContext(moduleMetadata, headers);
+
+    FolioExecutionContextUtils.prepareContextForTenant(newTenant, moduleMetadata, folioContext);
+
+    assertThat(folioContext.getTenantId()).isEqualTo(originalTenant);
+    assertThat(folioContext.getAllHeaders().get(TENANT)).containsOnly(originalTenant);
+  }
+
+  @Test
+  void testPrepareContextForTenantHandlesMixedCaseOkapiHeaderKeys() {
+    var originalTenant = "original";
+    var newTenant = "switched";
+    Map<String, Collection<String>> headers = new HashMap<>();
+    headers.put("X-Okapi-Tenant", singleton(originalTenant));
+    headers.put("X-Okapi-Token", singleton("my-token"));
+    var folioContext = new DefaultFolioExecutionContext(moduleMetadata, headers);
+
+    var actual = FolioExecutionContextUtils.prepareContextForTenant(newTenant, moduleMetadata, folioContext);
+
+    assertThat(actual.getTenantId()).isEqualTo(newTenant);
+    assertThat(actual.getToken()).isEqualTo("my-token");
   }
 }


### PR DESCRIPTION
## Purpose
Ensure that header lookups by well-known  XOkapiHeaders constants (e.g. x-okapi-tenant) find entries regardless of how the incoming headers were cased.

https://folio-org.atlassian.net/browse/FOLSPRINGS-234